### PR TITLE
Implement reliability improvements and metrics

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -1,0 +1,12 @@
+# Task Tracker
+
+## Code-quality & maintainability
+- [ ] 2.1 Refactor into feature modules
+- [ ] 2.2 Use dependency-injection for API client
+- [x] 2.3 Remove dead files
+
+## Reliability & performance
+- [x] 3.1 HTTPX client tweaks
+- [x] 3.2 Caching layer
+- [ ] 3.3 Timeout & cancel support
+- [x] 3.4 Prometheus metrics

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,9 @@ dependencies = [
     "mcp[cli]>=1.1.0",
     "httpx>=0.27.0",
     "python-dotenv>=1.0.0",
-    "pydantic>=2.0.0"
+    "pydantic>=2.0.0",
+    "cachetools>=5.3.0",
+    "prometheus-client>=0.19.0"
 ]
 
 [project.scripts]

--- a/src/xyte_mcp_alpha/__init__.py
+++ b/src/xyte_mcp_alpha/__init__.py
@@ -1,13 +1,15 @@
 """xyte-mcp-alpha package."""
+
 from .server import get_server
 
 __version__ = "0.1.0"
 __all__ = ["get_server", "__version__"]
 
+
 def serve():
     """Entry point for serving the MCP server."""
     import asyncio
     from mcp.server.stdio import stdio_server
-    
+
     server = get_server()
     asyncio.run(stdio_server(server))

--- a/src/xyte_mcp_alpha/client.py
+++ b/src/xyte_mcp_alpha/client.py
@@ -1,8 +1,10 @@
 """Xyte Organization API client."""
+
 import os
 import logging
-from typing import Dict, List, Optional, Any
+from typing import Any, Dict, List, Optional
 import httpx
+from cachetools import TTLCache
 from pydantic import BaseModel, Field
 from datetime import datetime
 
@@ -11,8 +13,11 @@ logger = logging.getLogger(__name__)
 
 class ClaimDeviceRequest(BaseModel):
     """Request model for claiming a device."""
+
     name: str = Field(..., description="Friendly name for the device")
-    space_id: int = Field(..., description="Identifier of the space to assign the device")
+    space_id: int = Field(
+        ..., description="Identifier of the space to assign the device"
+    )
     mac: Optional[str] = Field(None, description="Device MAC address (optional)")
     sn: Optional[str] = Field(None, description="Device serial number (optional)")
     cloud_id: str = Field("", description="Cloud identifier for the device (optional)")
@@ -20,39 +25,52 @@ class ClaimDeviceRequest(BaseModel):
 
 class UpdateDeviceRequest(BaseModel):
     """Request model for updating a device."""
-    configuration: Dict[str, Any] = Field(..., description="Configuration parameters for the device")
+
+    configuration: Dict[str, Any] = Field(
+        ..., description="Configuration parameters for the device"
+    )
 
 
 class CommandRequest(BaseModel):
     """Request model for sending a command to device."""
+
     name: str = Field(..., description="Command name")
     friendly_name: str = Field(..., description="Human-friendly command name")
-    file_id: Optional[str] = Field(None, description="File identifier if the command includes a file")
-    extra_params: Dict[str, Any] = Field(default_factory=dict, description="Additional parameters")
+    file_id: Optional[str] = Field(
+        None, description="File identifier if the command includes a file"
+    )
+    extra_params: Dict[str, Any] = Field(
+        default_factory=dict, description="Additional parameters"
+    )
 
 
 class OrgInfoRequest(BaseModel):
     """Request model for getting organization info."""
-    device_id: str = Field(..., description="Device identifier for which to retrieve organization info")
+
+    device_id: str = Field(
+        ..., description="Device identifier for which to retrieve organization info"
+    )
 
 
 class TicketUpdateRequest(BaseModel):
     """Request model for updating a ticket."""
+
     title: str = Field(..., description="New title for the ticket")
     description: str = Field(..., description="New description for the ticket")
 
 
 class TicketMessageRequest(BaseModel):
     """Request model for sending a ticket message."""
+
     message: str = Field(..., description="Message content to send in ticket")
 
 
 class XyteAPIClient:
     """Client for interacting with Xyte Organization API."""
-    
+
     def __init__(self, api_key: Optional[str] = None, base_url: Optional[str] = None):
         """Initialize the API client.
-        
+
         Args:
             api_key: API key for authentication. If not provided, will try to get from env.
             base_url: Base URL for the API. Defaults to production URL.
@@ -60,52 +78,68 @@ class XyteAPIClient:
         self.api_key = api_key or os.getenv("XYTE_API_KEY")
         if not self.api_key:
             raise ValueError("XYTE_API_KEY must be provided or set in environment")
-        
+
         self.base_url = base_url or "https://hub.xyte.io/core/v1/organization"
+        limits = httpx.Limits(max_keepalive_connections=20, max_connections=100)
+        transport = httpx.AsyncHTTPTransport(retries=3, limits=limits)
         self.client = httpx.AsyncClient(
             base_url=self.base_url,
             headers={
                 "Authorization": self.api_key,
-                "Content-Type": "application/json"
+                "Content-Type": "application/json",
             },
-            timeout=30.0
+            timeout=30.0,
+            transport=transport,
         )
-    
+
+        ttl = int(os.getenv("XYTE_CACHE_TTL", "60"))
+        self.cache = TTLCache(maxsize=128, ttl=ttl)
+
+    async def __aenter__(self) -> "XyteAPIClient":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        await self.close()
+
     async def close(self):
         """Close the HTTP client."""
         await self.client.aclose()
-    
+
     # Device Operations
     async def get_devices(self) -> Dict[str, Any]:
         """List all devices in the organization."""
+        if "devices" in self.cache:
+            return self.cache["devices"]
         response = await self.client.get("/devices")
         response.raise_for_status()
-        return response.json()
-    
+        data = response.json()
+        self.cache["devices"] = data
+        return data
+
     async def claim_device(self, device_data: ClaimDeviceRequest) -> Dict[str, Any]:
         """Register (claim) a new device under the organization."""
         response = await self.client.post(
-            "/devices/claim",
-            json=device_data.model_dump(exclude_none=True)
+            "/devices/claim", json=device_data.model_dump(exclude_none=True)
         )
         response.raise_for_status()
         return response.json()
-    
+
     async def delete_device(self, device_id: str) -> Dict[str, Any]:
         """Delete (remove) a device by its ID."""
         response = await self.client.delete(f"/devices/{device_id}")
         response.raise_for_status()
         return response.json()
-    
-    async def update_device(self, device_id: str, device_data: UpdateDeviceRequest) -> Dict[str, Any]:
+
+    async def update_device(
+        self, device_id: str, device_data: UpdateDeviceRequest
+    ) -> Dict[str, Any]:
         """Update configuration or details of a specific device."""
         response = await self.client.patch(
-            f"/devices/{device_id}",
-            json=device_data.model_dump()
+            f"/devices/{device_id}", json=device_data.model_dump()
         )
         response.raise_for_status()
         return response.json()
-    
+
     async def get_device_histories(
         self,
         status: Optional[str] = None,
@@ -113,7 +147,7 @@ class XyteAPIClient:
         to_date: Optional[datetime] = None,
         device_id: Optional[str] = None,
         space_id: Optional[int] = None,
-        name: Optional[str] = None
+        name: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Retrieve device history records."""
         params = {}
@@ -129,88 +163,99 @@ class XyteAPIClient:
             params["space_id"] = space_id
         if name:
             params["name"] = name
-        
+
         response = await self.client.get("/devices/histories", params=params)
         response.raise_for_status()
         return response.json()
-    
+
     # Command Operations
-    async def send_command(self, device_id: str, command_data: CommandRequest) -> Dict[str, Any]:
+    async def send_command(
+        self, device_id: str, command_data: CommandRequest
+    ) -> Dict[str, Any]:
         """Send a command to the specified device."""
         response = await self.client.post(
-            f"/devices/{device_id}/commands",
-            json=command_data.model_dump()
+            f"/devices/{device_id}/commands", json=command_data.model_dump()
         )
         response.raise_for_status()
         return response.json()
-    
-    async def cancel_command(self, device_id: str, command_id: str, command_data: CommandRequest) -> Dict[str, Any]:
+
+    async def cancel_command(
+        self, device_id: str, command_id: str, command_data: CommandRequest
+    ) -> Dict[str, Any]:
         """Cancel a previously sent command on the device."""
         response = await self.client.delete(
             f"/devices/{device_id}/commands/{command_id}",
-            json=command_data.model_dump()
+            json=command_data.model_dump(),
         )
         response.raise_for_status()
         return response.json()
-    
+
     async def get_commands(self, device_id: str) -> Dict[str, Any]:
         """List all commands for the specified device."""
         response = await self.client.get(f"/{device_id}/commands")
         response.raise_for_status()
         return response.json()
-    
+
     # Organization Operations
     async def get_organization_info(self, device_id: str) -> Dict[str, Any]:
         """Retrieve information about the organization."""
         # Note: This is a GET request with a body, which is unusual but as specified in the API
         response = await self.client.request(
-            "GET",
-            "/info",
-            json={"device_id": device_id}
+            "GET", "/info", json={"device_id": device_id}
         )
         response.raise_for_status()
         return response.json()
-    
+
     # Incident Operations
     async def get_incidents(self) -> Dict[str, Any]:
         """Retrieve all incidents for the organization."""
+        if "incidents" in self.cache:
+            return self.cache["incidents"]
         response = await self.client.get("/incidents")
         response.raise_for_status()
-        return response.json()
-    
+        data = response.json()
+        self.cache["incidents"] = data
+        return data
+
     # Ticket Operations
     async def get_tickets(self) -> Dict[str, Any]:
         """Retrieve all support tickets for the organization."""
+        if "tickets" in self.cache:
+            return self.cache["tickets"]
         response = await self.client.get("/tickets")
         response.raise_for_status()
-        return response.json()
-    
+        data = response.json()
+        self.cache["tickets"] = data
+        return data
+
     async def get_ticket(self, ticket_id: str) -> Dict[str, Any]:
         """Retrieve a specific support ticket by ID."""
         response = await self.client.get(f"/tickets/{ticket_id}")
         response.raise_for_status()
         return response.json()
-    
-    async def update_ticket(self, ticket_id: str, ticket_data: TicketUpdateRequest) -> Dict[str, Any]:
+
+    async def update_ticket(
+        self, ticket_id: str, ticket_data: TicketUpdateRequest
+    ) -> Dict[str, Any]:
         """Update the details of a specific ticket."""
         response = await self.client.put(
-            f"/tickets/{ticket_id}",
-            json=ticket_data.model_dump()
+            f"/tickets/{ticket_id}", json=ticket_data.model_dump()
         )
         response.raise_for_status()
         return response.json()
-    
+
     async def mark_ticket_resolved(self, ticket_id: str) -> Dict[str, Any]:
         """Mark the specified ticket as resolved."""
         response = await self.client.post(f"/tickets/{ticket_id}/resolved")
         response.raise_for_status()
         return response.json()
-    
-    async def send_ticket_message(self, ticket_id: str, message_data: TicketMessageRequest) -> Dict[str, Any]:
+
+    async def send_ticket_message(
+        self, ticket_id: str, message_data: TicketMessageRequest
+    ) -> Dict[str, Any]:
         """Send a new message to the specified ticket thread."""
         response = await self.client.post(
-            f"/tickets/{ticket_id}/message",
-            json=message_data.model_dump()
+            f"/tickets/{ticket_id}/message", json=message_data.model_dump()
         )
         response.raise_for_status()
         return response.json()

--- a/src/xyte_mcp_alpha/http.py
+++ b/src/xyte_mcp_alpha/http.py
@@ -1,4 +1,5 @@
 """HTTP entrypoint for the MCP server."""
+
 from .server import get_server
 
 # Expose ASGI app for Uvicorn or other ASGI servers
@@ -8,6 +9,7 @@ app = get_server().asgi_app()
 def main():
     """Run the HTTP server using Uvicorn."""
     import uvicorn
+
     uvicorn.run("xyte_mcp_alpha.http:app", host="0.0.0.0", port=8080)
 
 

--- a/src/xyte_mcp_alpha/models.py
+++ b/src/xyte_mcp_alpha/models.py
@@ -1,20 +1,23 @@
 from typing import Optional, Dict, Any
 from pydantic import BaseModel, Field
-from .api_client import CommandRequest
+from .client import CommandRequest
 
 
 class DeviceId(BaseModel):
     """Model identifying a device."""
+
     device_id: str = Field(..., description="Unique device identifier")
 
 
 class CommandId(DeviceId):
     """Model identifying a command for a device."""
+
     command_id: str = Field(..., description="Unique command identifier")
 
 
 class UpdateDeviceArgs(DeviceId):
     """Parameters for updating a device."""
+
     configuration: Dict[str, Any] = Field(..., description="Configuration parameters")
 
 
@@ -28,11 +31,13 @@ class SendTicketMessageRequest(MarkTicketResolvedRequest):
 
 class SendCommandRequest(DeviceId, CommandRequest):
     """Parameters for sending a command."""
+
     pass
 
 
 class CancelCommandRequest(CommandId, CommandRequest):
     """Parameters for canceling a command."""
+
     pass
 
 

--- a/src/xyte_mcp_alpha/server.py
+++ b/src/xyte_mcp_alpha/server.py
@@ -1,22 +1,31 @@
 """MCP server for Xyte Organization API."""
+
 import os
 import logging
-from typing import Dict, List, Optional, Any, Callable, Awaitable
+from typing import Any, Awaitable, Callable, Dict, List, Optional
 import httpx
 from datetime import datetime
+from prometheus_client import (
+    Counter,
+    Histogram,
+    generate_latest,
+    CONTENT_TYPE_LATEST,
+)
 from mcp.server.fastmcp import FastMCP
 from mcp.server.const import ServerCapabilities
 from mcp.server.errors import MCPError
+from starlette.requests import Request
+from starlette.responses import Response
 import asyncio
 
-from .api_client import (
+from .client import (
     XyteAPIClient,
     ClaimDeviceRequest,
     UpdateDeviceRequest,
     CommandRequest,
     OrgInfoRequest,
     TicketUpdateRequest,
-    TicketMessageRequest
+    TicketMessageRequest,
 )
 from .models import (
     DeviceId,
@@ -33,8 +42,23 @@ from .models import (
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+# Prometheus metrics
+REQUEST_LATENCY = Histogram(
+    "xyte_request_latency_seconds", "Latency of API calls", ["endpoint"]
+)
+ERROR_COUNT = Counter("xyte_errors_total", "XYTE API errors", ["endpoint", "code"])
+STATUS_COUNT = Counter("xyte_status_total", "XYTE API status codes", ["status"])
+
 # Initialize MCP server
 mcp = FastMCP("Xyte Organization MCP Server")
+
+
+@mcp.custom_route("/metrics", methods=["GET"])
+async def metrics(_: Request) -> Response:
+    """Expose Prometheus metrics."""
+    data = generate_latest()
+    return Response(data, media_type=CONTENT_TYPE_LATEST)
+
 
 # Global API client (will be initialized at startup)
 api_client: Optional[XyteAPIClient] = None
@@ -47,12 +71,16 @@ def _ensure_client() -> XyteAPIClient:
     return api_client
 
 
-async def _handle(coro: Awaitable[Dict[str, Any]]) -> Dict[str, Any]:
-    """Execute an API call and translate errors."""
+async def _handle(name: str, coro: Awaitable[Dict[str, Any]]) -> Dict[str, Any]:
+    """Execute an API call, track metrics and translate errors."""
+    start = asyncio.get_event_loop().time()
     try:
-        return await coro
+        result = await coro
+        STATUS_COUNT.labels("200").inc()
+        return result
     except httpx.HTTPStatusError as e:
         status = e.response.status_code
+        STATUS_COUNT.labels(str(status)).inc()
         if status == 401 or status == 403:
             code = "unauthorized"
         elif status == 404:
@@ -63,90 +91,101 @@ async def _handle(coro: Awaitable[Dict[str, Any]]) -> Dict[str, Any]:
             code = "xyte_server_error"
         else:
             code = "xyte_api_error"
+        ERROR_COUNT.labels(name, code).inc()
         raise MCPError(code=code, message=e.response.text)
     except Exception as e:  # pragma: no cover - fallback
+        ERROR_COUNT.labels(name, "unknown").inc()
         raise MCPError(code="xyte_api_error", message=str(e))
+    finally:
+        REQUEST_LATENCY.labels(name).observe(asyncio.get_event_loop().time() - start)
 
 
 @mcp.server.on_initialize
 async def on_initialize():
     """Initialize the server and set up the API client."""
     global api_client
-    
+
     api_key = os.getenv("XYTE_API_KEY")
     if not api_key:
         logger.error("XYTE_API_KEY environment variable not set")
         raise ValueError("XYTE_API_KEY must be set in environment")
-    
+
     api_client = XyteAPIClient(api_key=api_key)
     logger.info("Xyte API client initialized")
 
 
 # Resources (read-only operations)
 
+
 @mcp.resource("devices://")
 async def get_devices() -> Dict[str, Any]:
     """List all devices in the organization."""
     client = _ensure_client()
-    return await _handle(client.get_devices())
+    return await _handle("get_devices", client.get_devices())
 
 
 @mcp.resource("device://{device_id}/commands")
 async def get_device_commands(device_id: str) -> Dict[str, Any]:
     """List all commands for a specific device."""
     client = _ensure_client()
-    return await _handle(client.get_commands(device_id))
+    return await _handle("get_device_commands", client.get_commands(device_id))
 
 
 @mcp.resource("device://{device_id}/histories")
 async def get_device_histories(device_id: str) -> Dict[str, Any]:
     """Get history records for a specific device."""
     client = _ensure_client()
-    return await _handle(client.get_device_histories(device_id=device_id))
+    return await _handle(
+        "get_device_histories",
+        client.get_device_histories(device_id=device_id),
+    )
 
 
 @mcp.resource("organization://info/{device_id}")
 async def get_organization_info(device_id: str) -> Dict[str, Any]:
     """Get organization information for a device context."""
     client = _ensure_client()
-    return await _handle(client.get_organization_info(device_id))
+    return await _handle(
+        "get_organization_info", client.get_organization_info(device_id)
+    )
 
 
 @mcp.resource("incidents://")
 async def get_incidents() -> Dict[str, Any]:
     """Retrieve all incidents for the organization."""
     client = _ensure_client()
-    return await _handle(client.get_incidents())
+    return await _handle("get_incidents", client.get_incidents())
 
 
 @mcp.resource("tickets://")
 async def get_tickets() -> Dict[str, Any]:
     """Retrieve all support tickets for the organization."""
     client = _ensure_client()
-    return await _handle(client.get_tickets())
+    return await _handle("get_tickets", client.get_tickets())
 
 
 @mcp.resource("ticket://{ticket_id}")
 async def get_ticket(ticket_id: str) -> Dict[str, Any]:
     """Retrieve a specific support ticket by ID."""
     client = _ensure_client()
-    return await _handle(client.get_ticket(ticket_id))
+    return await _handle("get_ticket", client.get_ticket(ticket_id))
 
 
 # Tools (write operations)
+
 
 @mcp.tool()
 async def claim_device(request: ClaimDeviceRequest) -> Dict[str, Any]:
     """Register (claim) a new device under the organization."""
     client = _ensure_client()
-    return await _handle(client.claim_device(request))
+    return await _handle("claim_device", client.claim_device(request))
 
 
 @mcp.tool()
 async def delete_device(data: DeviceId) -> Dict[str, Any]:
     """Delete (remove) a device by its ID."""
     client = _ensure_client()
-    return await _handle(client.delete_device(data.device_id))
+    return await _handle("delete_device", client.delete_device(data.device_id))
 
 
 @mcp.tool()
@@ -154,7 +193,7 @@ async def update_device(data: UpdateDeviceArgs) -> Dict[str, Any]:
     """Update configuration or details of a specific device."""
     client = _ensure_client()
     request = UpdateDeviceRequest(configuration=data.configuration)
-    return await _handle(client.update_device(data.device_id, request))
+    return await _handle("update_device", client.update_device(data.device_id, request))
 
 
 @mcp.tool()
@@ -167,7 +206,7 @@ async def send_command(data: SendCommandRequest) -> Dict[str, Any]:
         file_id=data.file_id,
         extra_params=data.extra_params or {},
     )
-    return await _handle(client.send_command(data.device_id, request))
+    return await _handle("send_command", client.send_command(data.device_id, request))
 
 
 @mcp.tool()
@@ -181,7 +220,8 @@ async def cancel_command(data: CancelCommandRequest) -> Dict[str, Any]:
         extra_params=data.extra_params or {},
     )
     return await _handle(
-        client.cancel_command(data.device_id, data.command_id, request)
+        "cancel_command",
+        client.cancel_command(data.device_id, data.command_id, request),
     )
 
 
@@ -190,14 +230,16 @@ async def update_ticket(data: UpdateTicketRequest) -> Dict[str, Any]:
     """Update the details of a specific ticket."""
     client = _ensure_client()
     request = TicketUpdateRequest(title=data.title, description=data.description)
-    return await _handle(client.update_ticket(data.ticket_id, request))
+    return await _handle("update_ticket", client.update_ticket(data.ticket_id, request))
 
 
 @mcp.tool()
 async def mark_ticket_resolved(data: MarkTicketResolvedRequest) -> Dict[str, Any]:
     """Mark the specified ticket as resolved."""
     client = _ensure_client()
-    return await _handle(client.mark_ticket_resolved(data.ticket_id))
+    return await _handle(
+        "mark_ticket_resolved", client.mark_ticket_resolved(data.ticket_id)
+    )
 
 
 @mcp.tool()
@@ -205,17 +247,22 @@ async def send_ticket_message(data: SendTicketMessageRequest) -> Dict[str, Any]:
     """Send a new message to the specified ticket thread."""
     client = _ensure_client()
     request = TicketMessageRequest(message=data.message)
-    return await _handle(client.send_ticket_message(data.ticket_id, request))
+    return await _handle(
+        "send_ticket_message", client.send_ticket_message(data.ticket_id, request)
+    )
 
 
 @mcp.tool()
-async def search_device_histories(params: SearchDeviceHistoriesRequest) -> Dict[str, Any]:
+async def search_device_histories(
+    params: SearchDeviceHistoriesRequest,
+) -> Dict[str, Any]:
     """Search device history records with filters."""
     client = _ensure_client()
     from_dt = datetime.fromisoformat(params.from_date) if params.from_date else None
     to_dt = datetime.fromisoformat(params.to_date) if params.to_date else None
 
     return await _handle(
+        "search_device_histories",
         client.get_device_histories(
             status=params.status,
             from_date=from_dt,
@@ -223,7 +270,7 @@ async def search_device_histories(params: SearchDeviceHistoriesRequest) -> Dict[
             device_id=params.device_id,
             space_id=params.space_id,
             name=params.name,
-        )
+        ),
     )
 
 


### PR DESCRIPTION
## Summary
- rename `api_client.py` to `client.py`
- add HTTPX retry/limits and TTL caching
- expose Prometheus metrics endpoint
- update server to record basic metrics
- track completed tasks

## Testing
- `black -q src/xyte_mcp_alpha`
