### PR TITLE
Implement documentation and release updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## [1.0.0] - 2024-06-11
+### Added
+- Auto-generated MCP capability JSON in `docs/capabilities.json`.
+- Swagger-style documentation for XYTE wrappers in `docs/wrappers.md`.
+- Inline GIF demo for running `mcp dev`.
+
+### Changed
+- Project version bumped to **1.0.0**.
+

--- a/README.md
+++ b/README.md
@@ -123,25 +123,7 @@ Alternatively, with a Python virtual environment:
 
 ## Example Usage
 
-Once connected, you can interact with Xyte through Claude:
-
-**List devices:**
-- "Show me all devices in the organization"
-- "What devices are available?"
-
-**Device operations:**
-- "Claim a new device named 'Test Device' in space 13244"
-- "Update the configuration of device XYZ with {a: 1}"
-- "Send a reboot command to device ABC"
-
-**Ticket management:**
-- "Show me all open tickets"
-- "Update ticket #123 with a new title"
-- "Send a message to ticket #456"
-
-**History search:**
-- "Search device histories for the last 24 hours"
-- "Find histories for device XYZ from last week"
+![mcp dev demo](docs/mcp-dev.gif)
 
 ## Development
 

--- a/TODO.md
+++ b/TODO.md
@@ -33,13 +33,13 @@
 - [x] 6.3 Health & readiness probes
 
 ## Documentation
-- [ ] 7.1 Auto-generate MCP capability JSON
-- [ ] 7.2 Swagger-style docs for XYTE wrappers
-- [ ] 7.3 Replace README usage examples with runnable `mcp dev` GIF
+- [x] 7.1 Auto-generate MCP capability JSON
+- [x] 7.2 Swagger-style docs for XYTE wrappers
+- [x] 7.3 Replace README usage examples with runnable `mcp dev` GIF
 
 ## Versioning & release
-- [ ] 8.1 Semantic version bump to 1.0.0
-- [ ] 8.2 CHANGELOG.md with release notes
+- [x] 8.1 Semantic version bump to 1.0.0
+- [x] 8.2 CHANGELOG.md with release notes
 
 ## Community & contribution
 - [ ] 9.1 Contributing guide + code-of-conduct

--- a/docs/capabilities.json
+++ b/docs/capabilities.json
@@ -1,0 +1,548 @@
+{
+  "capabilities": {
+    "experimental": {},
+    "logging": null,
+    "prompts": {
+      "listChanged": false
+    },
+    "resources": {
+      "subscribe": false,
+      "listChanged": false
+    },
+    "tools": {
+      "listChanged": false
+    }
+  },
+  "tools": [
+    {
+      "name": "claim_device",
+      "description": "",
+      "inputSchema": {
+        "$defs": {
+          "ClaimDeviceRequest": {
+            "description": "Request model for claiming a device.",
+            "properties": {
+              "name": {
+                "description": "Friendly name for the device",
+                "title": "Name",
+                "type": "string"
+              },
+              "space_id": {
+                "description": "Identifier of the space to assign the device",
+                "title": "Space Id",
+                "type": "integer"
+              },
+              "mac": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Device MAC address (optional)",
+                "title": "Mac"
+              },
+              "sn": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Device serial number (optional)",
+                "title": "Sn"
+              },
+              "cloud_id": {
+                "default": "",
+                "description": "Cloud identifier for the device (optional)",
+                "title": "Cloud Id",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "space_id"
+            ],
+            "title": "ClaimDeviceRequest",
+            "type": "object"
+          }
+        },
+        "properties": {
+          "request": {
+            "$ref": "#/$defs/ClaimDeviceRequest"
+          }
+        },
+        "required": [
+          "request"
+        ],
+        "title": "claim_deviceArguments",
+        "type": "object"
+      },
+      "annotations": null
+    },
+    {
+      "name": "delete_device",
+      "description": "",
+      "inputSchema": {
+        "$defs": {
+          "DeviceId": {
+            "description": "Model identifying a device.",
+            "properties": {
+              "device_id": {
+                "description": "Unique device identifier",
+                "title": "Device Id",
+                "type": "string"
+              }
+            },
+            "required": [
+              "device_id"
+            ],
+            "title": "DeviceId",
+            "type": "object"
+          }
+        },
+        "properties": {
+          "data": {
+            "$ref": "#/$defs/DeviceId"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "title": "delete_deviceArguments",
+        "type": "object"
+      },
+      "annotations": null
+    },
+    {
+      "name": "update_device",
+      "description": "",
+      "inputSchema": {
+        "$defs": {
+          "UpdateDeviceArgs": {
+            "description": "Parameters for updating a device.",
+            "properties": {
+              "device_id": {
+                "description": "Unique device identifier",
+                "title": "Device Id",
+                "type": "string"
+              },
+              "configuration": {
+                "additionalProperties": true,
+                "description": "Configuration parameters",
+                "title": "Configuration",
+                "type": "object"
+              }
+            },
+            "required": [
+              "device_id",
+              "configuration"
+            ],
+            "title": "UpdateDeviceArgs",
+            "type": "object"
+          }
+        },
+        "properties": {
+          "data": {
+            "$ref": "#/$defs/UpdateDeviceArgs"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "title": "update_deviceArguments",
+        "type": "object"
+      },
+      "annotations": null
+    },
+    {
+      "name": "send_command",
+      "description": "",
+      "inputSchema": {
+        "$defs": {
+          "SendCommandRequest": {
+            "description": "Parameters for sending a command.",
+            "properties": {
+              "name": {
+                "description": "Command name",
+                "title": "Name",
+                "type": "string"
+              },
+              "friendly_name": {
+                "description": "Human-friendly command name",
+                "title": "Friendly Name",
+                "type": "string"
+              },
+              "file_id": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "File identifier if the command includes a file",
+                "title": "File Id"
+              },
+              "extra_params": {
+                "additionalProperties": true,
+                "description": "Additional parameters",
+                "title": "Extra Params",
+                "type": "object"
+              },
+              "device_id": {
+                "description": "Unique device identifier",
+                "title": "Device Id",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "friendly_name",
+              "device_id"
+            ],
+            "title": "SendCommandRequest",
+            "type": "object"
+          }
+        },
+        "properties": {
+          "data": {
+            "$ref": "#/$defs/SendCommandRequest"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "title": "send_commandArguments",
+        "type": "object"
+      },
+      "annotations": null
+    },
+    {
+      "name": "cancel_command",
+      "description": "",
+      "inputSchema": {
+        "$defs": {
+          "CancelCommandRequest": {
+            "description": "Parameters for canceling a command.",
+            "properties": {
+              "name": {
+                "description": "Command name",
+                "title": "Name",
+                "type": "string"
+              },
+              "friendly_name": {
+                "description": "Human-friendly command name",
+                "title": "Friendly Name",
+                "type": "string"
+              },
+              "file_id": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "File identifier if the command includes a file",
+                "title": "File Id"
+              },
+              "extra_params": {
+                "additionalProperties": true,
+                "description": "Additional parameters",
+                "title": "Extra Params",
+                "type": "object"
+              },
+              "device_id": {
+                "description": "Unique device identifier",
+                "title": "Device Id",
+                "type": "string"
+              },
+              "command_id": {
+                "description": "Unique command identifier",
+                "title": "Command Id",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "friendly_name",
+              "device_id",
+              "command_id"
+            ],
+            "title": "CancelCommandRequest",
+            "type": "object"
+          }
+        },
+        "properties": {
+          "data": {
+            "$ref": "#/$defs/CancelCommandRequest"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "title": "cancel_commandArguments",
+        "type": "object"
+      },
+      "annotations": null
+    },
+    {
+      "name": "update_ticket",
+      "description": "",
+      "inputSchema": {
+        "$defs": {
+          "UpdateTicketRequest": {
+            "properties": {
+              "ticket_id": {
+                "description": "Unique ticket identifier",
+                "title": "Ticket Id",
+                "type": "string"
+              },
+              "title": {
+                "description": "New title for the ticket",
+                "title": "Title",
+                "type": "string"
+              },
+              "description": {
+                "description": "New description",
+                "title": "Description",
+                "type": "string"
+              }
+            },
+            "required": [
+              "ticket_id",
+              "title",
+              "description"
+            ],
+            "title": "UpdateTicketRequest",
+            "type": "object"
+          }
+        },
+        "properties": {
+          "data": {
+            "$ref": "#/$defs/UpdateTicketRequest"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "title": "update_ticketArguments",
+        "type": "object"
+      },
+      "annotations": null
+    },
+    {
+      "name": "mark_ticket_resolved",
+      "description": "",
+      "inputSchema": {
+        "$defs": {
+          "MarkTicketResolvedRequest": {
+            "properties": {
+              "ticket_id": {
+                "description": "Unique ticket identifier",
+                "title": "Ticket Id",
+                "type": "string"
+              }
+            },
+            "required": [
+              "ticket_id"
+            ],
+            "title": "MarkTicketResolvedRequest",
+            "type": "object"
+          }
+        },
+        "properties": {
+          "data": {
+            "$ref": "#/$defs/MarkTicketResolvedRequest"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "title": "mark_ticket_resolvedArguments",
+        "type": "object"
+      },
+      "annotations": null
+    },
+    {
+      "name": "send_ticket_message",
+      "description": "",
+      "inputSchema": {
+        "$defs": {
+          "SendTicketMessageRequest": {
+            "properties": {
+              "ticket_id": {
+                "description": "Unique ticket identifier",
+                "title": "Ticket Id",
+                "type": "string"
+              },
+              "message": {
+                "description": "Message content to send",
+                "title": "Message",
+                "type": "string"
+              }
+            },
+            "required": [
+              "ticket_id",
+              "message"
+            ],
+            "title": "SendTicketMessageRequest",
+            "type": "object"
+          }
+        },
+        "properties": {
+          "data": {
+            "$ref": "#/$defs/SendTicketMessageRequest"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "title": "send_ticket_messageArguments",
+        "type": "object"
+      },
+      "annotations": null
+    },
+    {
+      "name": "search_device_histories",
+      "description": "",
+      "inputSchema": {
+        "$defs": {
+          "SearchDeviceHistoriesRequest": {
+            "properties": {
+              "status": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Filter by status",
+                "title": "Status"
+              },
+              "from_date": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Start ISO time",
+                "title": "From Date"
+              },
+              "to_date": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "End ISO time",
+                "title": "To Date"
+              },
+              "device_id": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Filter by device",
+                "title": "Device Id"
+              },
+              "space_id": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Filter by space",
+                "title": "Space Id"
+              },
+              "name": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Filter by name",
+                "title": "Name"
+              }
+            },
+            "title": "SearchDeviceHistoriesRequest",
+            "type": "object"
+          }
+        },
+        "properties": {
+          "params": {
+            "$ref": "#/$defs/SearchDeviceHistoriesRequest"
+          }
+        },
+        "required": [
+          "params"
+        ],
+        "title": "search_device_historiesArguments",
+        "type": "object"
+      },
+      "annotations": null
+    }
+  ],
+  "resources": [
+    {
+      "uri": "devices://",
+      "name": "list_devices",
+      "description": "",
+      "mimeType": "text/plain",
+      "size": null,
+      "annotations": null
+    },
+    {
+      "uri": "incidents://",
+      "name": "list_incidents",
+      "description": "",
+      "mimeType": "text/plain",
+      "size": null,
+      "annotations": null
+    },
+    {
+      "uri": "tickets://",
+      "name": "list_tickets",
+      "description": "",
+      "mimeType": "text/plain",
+      "size": null,
+      "annotations": null
+    }
+  ],
+  "prompts": []
+}

--- a/docs/wrappers.md
+++ b/docs/wrappers.md
@@ -1,0 +1,28 @@
+# XYTE API Wrappers
+
+## Tools
+
+| Name | Parameters |
+| ---- | ---------- |
+| `claim_device` | name, space_id, mac, sn, cloud_id |
+| `delete_device` | device_id |
+| `update_device` | device_id, configuration |
+| `send_command` | name, friendly_name, file_id, extra_params, device_id |
+| `cancel_command` | name, friendly_name, file_id, extra_params, device_id, command_id |
+| `update_ticket` | ticket_id, title, description |
+| `mark_ticket_resolved` | ticket_id |
+| `send_ticket_message` | ticket_id, message |
+| `search_device_histories` | status, from_date, to_date, device_id, space_id, name |
+
+## Resources
+
+| URI | Name |
+| --- | ---- |
+| `devices://` | list_devices |
+| `incidents://` | list_incidents |
+| `tickets://` | list_tickets |
+| `device://{device_id}/commands` | list_device_commands |
+| `device://{device_id}/histories` | list_device_histories |
+| `organization://info/{device_id}` | organization_info |
+| `ticket://{ticket_id}` | get_ticket |
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "xyte-mcp-alpha"
-version = "0.1.0"
+version = "1.0.0"
 description = "MCP server for Xyte organization API"
 authors = [{name = "Your Name", email = "your.email@example.com"}]
 license = {text = "MIT"}

--- a/scripts/generate_capabilities.py
+++ b/scripts/generate_capabilities.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+import sys
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+import asyncio
+import json
+from mcp.server.lowlevel.server import NotificationOptions
+
+from xyte_mcp_alpha.server import get_server
+
+
+async def main() -> None:
+    server = get_server()
+    tools = [t.model_dump(mode="json") for t in await server.list_tools()]
+    resources = [r.model_dump(mode="json") for r in await server.list_resources()]
+    prompts = [p.model_dump(mode="json") for p in await server.list_prompts()]
+
+    mcp_server = server._mcp_server
+    capabilities = mcp_server.get_capabilities(NotificationOptions(), {})
+
+    spec = {
+        "capabilities": capabilities.model_dump(mode="json"),
+        "tools": tools,
+        "resources": resources,
+        "prompts": prompts,
+    }
+
+    out_file = Path("docs/capabilities.json")
+    out_file.write_text(json.dumps(spec, indent=2))
+    print(f"Wrote {out_file}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/generate_wrappers_md.py
+++ b/scripts/generate_wrappers_md.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+import sys
+import asyncio
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from xyte_mcp_alpha.server import get_server
+
+
+def extract_fields(schema: dict) -> str:
+    if not schema:
+        return ""
+    props = schema.get("properties", {})
+    if not props:
+        return ""
+    first = next(iter(props.values()))
+    if "$ref" in first:
+        ref = first["$ref"].split("/")[-1]
+        defs = schema.get("$defs", {}) or schema.get("definitions", {})
+        subprops = defs.get(ref, {}).get("properties", {})
+    else:
+        subprops = props
+    return ", ".join(subprops.keys())
+
+
+async def main() -> None:
+    server = get_server()
+    tools = await server.list_tools()
+    resources = await server.list_resources()
+    templates = await server.list_resource_templates()
+
+    lines = ["# XYTE API Wrappers", "", "## Tools", "", "| Name | Parameters |", "| ---- | ---------- |"]
+    for t in tools:
+        params = extract_fields(t.inputSchema)
+        lines.append(f"| `{t.name}` | {params} |")
+
+    lines.extend(["", "## Resources", "", "| URI | Name |", "| --- | ---- |"])
+    for r in resources:
+        lines.append(f"| `{r.uri}` | {r.name} |")
+    for tmpl in templates:
+        lines.append(f"| `{tmpl.uriTemplate}` | {tmpl.name or ''} |")
+
+    Path("docs/wrappers.md").write_text("\n".join(lines))
+    print("Generated docs/wrappers.md")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/xyte_mcp_alpha/__init__.py
+++ b/src/xyte_mcp_alpha/__init__.py
@@ -9,7 +9,7 @@ load_dotenv()
 
 load_dotenv()
 
-__version__ = "0.1.0"
+__version__ = "1.0.0"
 __all__ = ["get_server", "__version__"]
 
 


### PR DESCRIPTION
## Summary
- generate docs/capabilities.json using helper script
- add swagger-like table docs for wrappers
- embed mcp dev gif in README
- bump version to 1.0.0 and add CHANGELOG

## Testing
- `pytest -q` *(fails: command not found)*