### PR TITLE
Fix ruff unused import warning

### DIFF
--- a/src/xyte_mcp_alpha/__init__.py
+++ b/src/xyte_mcp_alpha/__init__.py
@@ -7,10 +7,8 @@ from .config import get_settings
 
 load_dotenv()
 
-load_dotenv()
-
 __version__ = "1.0.0"
-__all__ = ["get_server", "__version__"]
+__all__ = ["get_server", "get_settings", "__version__"]
 
 
 def serve():


### PR DESCRIPTION
## Summary
- expose `get_settings` via `__all__` in `__init__`
- remove duplicate `load_dotenv` call

## Testing
- `ruff check src tests`