### PR TITLE
Add deployment and plugin docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,17 @@ An MCP (Model Context Protocol) server that provides access to the Xyte Organiza
 2. Create a virtualenv and install the project: `pip install -e .`.
 3. Copy `.env.example` to `.env` and set `XYTE_API_KEY` (and optional `XYTE_USER_TOKEN`).
 4. Run the server with `serve` or `python -m xyte_mcp_alpha`.
+## Setup
+
+### Development
+1. Install extra dev dependencies with `pip install -e .[dev]`.
+2. Start the server using `mcp dev src/xyte_mcp_alpha/server.py` to get the interactive inspector.
+
+### Production
+1. Build the Docker image or install the package on your host.
+2. Set environment variables such as `XYTE_API_KEY` and `XYTE_BASE_URL`.
+3. Run `python -m xyte_mcp_alpha.http` under a process manager.
+
 
 ## Features
 
@@ -70,6 +81,12 @@ cp .env.example .env
 ```
 XYTE_API_KEY=your-actual-api-key-here
 ```
+
+3. Configure optional variables as needed:
+   - `XYTE_BASE_URL` - override the Xyte API base URL.
+   - `XYTE_USER_TOKEN` - user-scoped token if acting on behalf of a specific user.
+   - `XYTE_RATE_LIMIT` - requests per minute limit (defaults to 60).
+   - `XYTE_PLUGINS` - comma-separated list of plugin modules to load.
 
 ## Usage
 
@@ -134,8 +151,26 @@ Alternatively, with a Python virtual environment:
 ```
 
 ## Example Usage
+## API Usage Examples
+
+Python:
+```python
+import os, requests
+resp = requests.get("http://localhost:8080/devices", headers={"Authorization": os.getenv("XYTE_API_KEY")})
+print(resp.json())
+```
+
+Curl:
+```bash
+curl -H "Authorization: $XYTE_API_KEY" http://localhost:8080/devices
+```
 
 ![mcp dev demo](docs/mcp-dev.gif)
+## Architecture Overview
+The server is built on [FastMCP](https://github.com/anthropics/fastmcp) and organizes functionality into **resources** for read-only data and **tools** for actions.
+Events emitted by the Xyte API are queued internally and can trigger plugins.
+The plugin system loads modules listed in `XYTE_PLUGINS`, allowing hooks on events and logs.
+
 
 ## Development
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,39 @@
+# Deployment Guide
+
+This project provides a Helm chart and raw Kubernetes manifests for deploying the
+MCP server.
+
+## Installing with Helm
+
+1. Ensure you have `helm` installed and access to a Kubernetes cluster.
+2. Set the required API key and install the chart:
+   ```bash
+   helm install xyte ./helm \
+     --set env.XYTE_API_KEY=YOUR_KEY
+   ```
+3. Override `image.repository` or `image.tag` if you push a custom image.
+
+## Key Values
+
+- **image.repository** – Docker image to run.
+- **image.tag** – Image tag, defaults to `latest`.
+- **service.type** – Service type (`ClusterIP`, `LoadBalancer`, etc.).
+- **env.*** – Environment variables passed through to the container.
+
+See `helm/values.yaml` for the full list of configurable options.
+
+## Raw Manifests
+
+The `k8s/` directory contains plain manifests matching the chart. Apply them
+with `kubectl apply -f k8s/` if you prefer not to use Helm.
+
+## Upgrades and Rollbacks
+
+Upgrade the release with:
+```bash
+helm upgrade xyte ./helm -f my-values.yaml
+```
+If something goes wrong you can roll back:
+```bash
+helm rollback xyte
+```

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -1,0 +1,41 @@
+# Plugin System
+
+This server supports lightweight plugins that can react to events and logs.
+Plugins are regular Python modules referenced in the `XYTE_PLUGINS` environment
+variable as a comma separated list. Each module should expose an object with
+`on_event` and/or `on_log` methods.
+
+## Writing a Plugin
+
+1. Create a Python module (e.g. `myplugin.py`).
+2. Implement a class with optional `on_event(event: dict)` and
+   `on_log(message: str, level: int)` methods.
+3. Export an instance named `plugin` so the loader can discover it.
+4. Set `XYTE_PLUGINS=myplugin` before starting the server.
+
+````python
+# myplugin.py
+class MyPlugin:
+    def on_event(self, event: dict) -> None:
+        print("event", event)
+
+    def on_log(self, message: str, level: int) -> None:
+        print("log", level, message)
+
+plugin = MyPlugin()
+````
+
+Plugins may also call `register_payload_transform` to modify API responses before
+they reach the client.
+
+## Registration
+
+Set the environment variable and restart the server:
+
+```bash
+export XYTE_PLUGINS=myplugin,other.plugin
+python -m xyte_mcp_alpha
+```
+
+All listed plugins will be loaded at startup. Failures are logged but do not stop
+startup.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -2,22 +2,22 @@
 
 ## 🚩 **Documentation**
 
-* [ ] Expand `README.md` with:
+* [x] Expand `README.md` with:
 
-    * [ ] Setup steps (dev/prod)
-    * [ ] Configuration guide (env vars, options)
-    * [ ] API usage examples (code/curl)
-    * [ ] Explanation of core components and architecture
-* [ ] Create `docs/PLUGINS.md` with:
+    * [x] Setup steps (dev/prod)
+    * [x] Configuration guide (env vars, options)
+    * [x] API usage examples (code/curl)
+    * [x] Explanation of core components and architecture
+* [x] Create `docs/PLUGINS.md` with:
 
-    * [ ] Plugin architecture overview
-    * [ ] Step-by-step plugin development/registration guide
-    * [ ] Realistic code examples
-* [ ] Add `docs/DEPLOYMENT.md`:
+    * [x] Plugin architecture overview
+    * [x] Step-by-step plugin development/registration guide
+    * [x] Realistic code examples
+* [x] Add `docs/DEPLOYMENT.md`:
 
-    * [ ] Kubernetes/Helm install instructions
-    * [ ] Explanation of key Helm values and manifests
-    * [ ] Upgrade and rollback notes
+    * [x] Kubernetes/Helm install instructions
+    * [x] Explanation of key Helm values and manifests
+    * [x] Upgrade and rollback notes
 
 ## ✅ **Testing**
 


### PR DESCRIPTION
## Summary
- add development and production setup to README
- document environment variables and API usage examples
- describe server architecture
- create plugin guide and deployment notes
- mark documentation tasks complete in todo list

## Testing
- `pytest -q` *(fails: command not found)*