### PR TITLE
Add unified logging and observability docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,10 +163,20 @@ This opens an interactive UI where you can test tools and resources.
 
 ## Logging and Monitoring
 
-Structured JSON logs are produced for every HTTP request and Xyte API call. Each
-log entry includes a unique `request_id` for easy tracing. Prometheus metrics are
-available at the `/metrics` endpoint, including latency histograms for tools,
-resources and underlying API calls.
+The server emits structured JSON logs for all incoming requests, resource
+lookups and tool invocations. The helper `configure_logging()` function sets up
+logging on startup using the `XYTE_LOG_LEVEL` environment variable (default
+`INFO`). Supported levels are the standard Python log levels (`DEBUG`, `INFO`,
+`WARNING`, `ERROR`).
+
+Every log entry includes a `request_id` so you can trace a call across multiple
+actions. Logs are written to stderr and are also forwarded to any loaded
+plugins.
+
+Prometheus metrics are exposed at the `/metrics` endpoint. These include request
+counts and latency histograms for tools, resources and underlying API calls. You
+can visualize them using Grafana (see `docs/grafana_dashboard.json` for an
+example dashboard).
 
 ## API Reference
 

--- a/docs/grafana_dashboard.json
+++ b/docs/grafana_dashboard.json
@@ -1,0 +1,28 @@
+{
+  "title": "Xyte MCP Overview",
+  "schemaVersion": 30,
+  "panels": [
+    {
+      "type": "graph",
+      "title": "HTTP Requests",
+      "targets": [
+        {
+          "expr": "sum(rate(xyte_http_requests_total[1m]))",
+          "legendFormat": "requests/sec"
+        }
+      ],
+      "datasource": "Prometheus"
+    },
+    {
+      "type": "graph",
+      "title": "Tool Latency",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(xyte_tool_latency_seconds_bucket[5m])) by (le,tool))",
+          "legendFormat": "{{tool}}"
+        }
+      ],
+      "datasource": "Prometheus"
+    }
+  ]
+}

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -38,10 +38,10 @@
 
 ## 📜 **Logging & Observability**
 
-* [ ] Unify logging (one utility, consistent usage)
-* [ ] Document logging configuration and log levels
-* [ ] Ensure all core actions/events are logged
-* [ ] Provide example Grafana dashboard for Prometheus metrics
+* [x] Unify logging (one utility, consistent usage)
+* [x] Document logging configuration and log levels
+* [x] Ensure all core actions/events are logged
+* [x] Provide example Grafana dashboard for Prometheus metrics
 
 ## 🔒 **Security**
 

--- a/src/xyte_mcp_alpha/config.py
+++ b/src/xyte_mcp_alpha/config.py
@@ -23,6 +23,7 @@ class Settings(BaseSettings):
     )
     xyte_api_mapping: str | None = Field(default=None, alias="XYTE_API_MAPPING")
     xyte_hooks_module: str | None = Field(default=None, alias="XYTE_HOOKS_MODULE")
+    log_level: str = Field(default="INFO", alias="XYTE_LOG_LEVEL")
 
 
 @lru_cache()

--- a/src/xyte_mcp_alpha/logging_utils.py
+++ b/src/xyte_mcp_alpha/logging_utils.py
@@ -83,8 +83,14 @@ class StderrConsoleSpanExporter(ConsoleSpanExporter):
             return f"[{span.name}] {span.start_time} - {span.end_time}"
 
 
-def configure_logging(level: int = logging.INFO) -> None:
+def configure_logging(level: int | None = None) -> None:
     """Configure application-wide structured logging."""
+    from .config import get_settings
+
+    if level is None:
+        level_name = get_settings().log_level.upper()
+        level = getattr(logging, level_name, logging.INFO)
+
     # Configure logging to stderr to avoid interfering with MCP protocol
     logging.basicConfig(
         level=level,

--- a/src/xyte_mcp_alpha/server.py
+++ b/src/xyte_mcp_alpha/server.py
@@ -280,7 +280,9 @@ def get_server() -> Any:
 
 # Allow direct execution for development
 if __name__ == "__main__":
-    print("Starting MCP server in development mode...", file=sys.stderr)
+    from .logging_utils import log_json
+
+    log_json(logging.INFO, event="server_start", mode="development")
     import asyncio
     from mcp.server.stdio import stdio_server
 

--- a/src/xyte_mcp_alpha/tasks.py
+++ b/src/xyte_mcp_alpha/tasks.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 import asyncio
 from uuid import uuid4
 from typing import Dict, Any
+import logging
 
 from mcp.server.fastmcp import Context
 
 from .deps import get_client
 from .utils import handle_api
 from .models import SendCommandRequest
+from .logging_utils import log_json
 
 
 class TaskInfo:
@@ -27,6 +29,7 @@ async def send_command_async(data: SendCommandRequest, ctx: Context) -> Dict[str
     task_id = str(uuid4())
     info = TaskInfo()
     TASKS[task_id] = info
+    log_json(logging.INFO, event="task_created", task_id=task_id)
 
     async def _runner() -> None:
         try:
@@ -36,9 +39,11 @@ async def send_command_async(data: SendCommandRequest, ctx: Context) -> Dict[str
             info.result = result
             info.status = "done"
             await ctx.report_progress(100, 100)
+            log_json(logging.INFO, event="task_complete", task_id=task_id)
         except Exception as e:  # pragma: no cover - background
             info.status = "error"
             info.error = str(e)
+            log_json(logging.ERROR, event="task_error", task_id=task_id, error=str(e))
 
     asyncio.create_task(_runner())
     return {"task_id": task_id}
@@ -48,6 +53,8 @@ async def get_task_status(task_id: str) -> Dict[str, Any]:
     """Return status information about a previously started task."""
     info = TASKS.get(task_id)
     if not info:
+        log_json(logging.INFO, event="task_status_unknown", task_id=task_id)
         return {"status": "unknown"}
+    log_json(logging.INFO, event="task_status", task_id=task_id, status=info.status)
     return {"status": info.status, "result": info.result, "error": info.error}
 


### PR DESCRIPTION
## Summary
- unify logging through `log_json`
- document log configuration and add example Grafana dashboard
- ensure events and async tasks are logged
- respect XYTE_LOG_LEVEL setting
- check off logging items in todo list

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*