### PR TITLE
Add SQLModel task DB and Celery worker

### DIFF
--- a/src/xyte_mcp_alpha/celery_app.py
+++ b/src/xyte_mcp_alpha/celery_app.py
@@ -1,0 +1,15 @@
+import os
+from celery import Celery
+
+celery_app = Celery(
+    "xyte_mcp",
+    broker=os.getenv("REDIS_URL", "redis://localhost:6379/0"),
+    backend=os.getenv(
+        "DATABASE_URL", "postgresql+asyncpg://mcp:pass@127.0.0.1/mcp"
+    ),
+)
+celery_app.conf.update(
+    task_acks_late=True,
+    task_reject_on_worker_lost=True,
+    task_routes={"xyte_mcp_alpha.worker.long.*": {"queue": "long"}},
+)

--- a/src/xyte_mcp_alpha/db.py
+++ b/src/xyte_mcp_alpha/db.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import os
+from typing import AsyncGenerator
+
+from sqlmodel import SQLModel
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+DATABASE_URL = os.getenv(
+    "DATABASE_URL", "postgresql+asyncpg://mcp:pass@127.0.0.1/mcp"
+)
+
+_engine = create_async_engine(DATABASE_URL, future=True)
+_SessionLocal = sessionmaker(
+    _engine, class_=AsyncSession, expire_on_commit=False
+)
+
+
+async def get_session() -> AsyncGenerator[AsyncSession, None]:
+    async with _SessionLocal() as session:
+        yield session
+
+
+async def init_db() -> None:
+    async with _engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)

--- a/src/xyte_mcp_alpha/worker/long.py
+++ b/src/xyte_mcp_alpha/worker/long.py
@@ -1,0 +1,20 @@
+import asyncio
+from xyte_mcp_alpha.celery_app import celery_app
+from xyte_mcp_alpha.tasks import save, Task
+from xyte_mcp_alpha.client import XyteAPIClient
+
+
+@celery_app.task(name="xyte_mcp_alpha.worker.long.send_command")
+def send_command_long(task_id: str, payload: dict, xyte_key: str) -> None:
+    async def _run() -> None:
+        await save(Task(id=task_id, status="running"))
+        client = XyteAPIClient(api_key=xyte_key)
+        try:
+            result = await client.send_command(**payload)
+            await save(Task(id=task_id, status="done", result=result))
+        except Exception as exc:  # pragma: no cover - best effort
+            await save(Task(id=task_id, status="error", result={"msg": str(exc)}))
+        finally:
+            await client.close()
+
+    asyncio.run(_run())

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,51 +1,87 @@
 import asyncio
 import unittest
+from unittest.mock import patch
+
+from sqlmodel import SQLModel, Session, create_engine
 
 from xyte_mcp_alpha import tasks
 from xyte_mcp_alpha.models import SendCommandRequest
 
 
 class DummyCtx:
-    async def report_progress(self, current: int, total: int) -> None:
+    def __init__(self) -> None:
+        class ReqState:
+            xyte_key = "X" * 40
+        class Req:
+            state = ReqState()
+        class RC:
+            request = Req()
+        self.request_context = RC()
+
+    async def report_progress(self, current: int, total: int, message: str | None = None) -> None:
         pass
 
 
 class TaskStatusTestCase(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self) -> None:
+        self.engine = create_engine("sqlite:///:memory:")
+        SQLModel.metadata.create_all(self.engine)
+
+        class DummyAsyncSession:
+            def __init__(self, engine):
+                self.session = Session(engine)
+
+            async def merge(self, obj):
+                self.session.merge(obj)
+
+            async def commit(self):
+                self.session.commit()
+
+            async def get(self, model, pk):
+                return self.session.get(model, pk)
+
+            async def close(self):
+                self.session.close()
+
+        from contextlib import asynccontextmanager
+
+        @asynccontextmanager
+        async def get_session():
+            s = DummyAsyncSession(self.engine)
+            try:
+                yield s
+            finally:
+                await s.close()
+
+        self.get_session_patch = patch("xyte_mcp_alpha.tasks.get_session", get_session)
+        self.get_session_patch.start()
+
+    async def asyncTearDown(self) -> None:
+        self.get_session_patch.stop()
+        self.engine.dispose()
+
     async def test_get_task_status_unknown(self):
         status = await tasks.get_task_status("missing")
         self.assertEqual(status["status"], "unknown")
 
     async def test_send_command_async(self):
-        async def fake_send_command(device_id, data):
-            return {"ok": True}
+        captured: dict = {}
 
-        class DummyClient:
-            async def __aenter__(self):
-                return self
+        def fake_delay(tid: str, payload: dict, key: str) -> None:
+            captured["tid"] = tid
+            asyncio.get_event_loop().create_task(
+                tasks.save(tasks.Task(id=tid, status="done", result={"ok": True}))
+            )
 
-            async def __aexit__(self, exc_type, exc, tb):
-                pass
-
-            async def send_command(self, device_id, data):
-                return await fake_send_command(device_id, data)
-
-        def get_client(*args, **kwargs):
-            return DummyClient()
-
-        original_get_client = tasks.get_client
-        tasks.get_client = get_client  # type: ignore
-        try:
+        with patch("xyte_mcp_alpha.worker.long.send_command_long.delay", side_effect=fake_delay):
+            ctx = DummyCtx()
             req = SendCommandRequest(device_id="1", name="ping", friendly_name="Ping")
-            result = await tasks.send_command_async(req, DummyCtx())
-            self.assertIn("task_id", result)
-            status = await tasks.get_task_status(result["task_id"])
-            # Wait a short time for background task
-            await asyncio.sleep(0.1)
-            status = await tasks.get_task_status(result["task_id"])
+            resp = await tasks.send_command_async(req, ctx)
+            tid = resp.data["task_id"]
+            await asyncio.sleep(0.05)
+            status = await tasks.get_task_status(tid)
             self.assertEqual(status["status"], "done")
-        finally:
-            tasks.get_client = original_get_client  # type: ignore
-            tasks.TASKS.clear()
+            self.assertEqual(captured["tid"], tid)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- implement async Postgres DB access via SQLModel
- add Celery app and long-running command worker
- refactor tasks module to use DB and Celery
- update tests for new DB layer and worker integration

## Testing
- `venv/bin/python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683eedf05f44832584e3ca70fb49a651