### PR TITLE
Add deployment files and docs

### DIFF
--- a/DEPLOYMENT-PROGRESS.md
+++ b/DEPLOYMENT-PROGRESS.md
@@ -6,3 +6,6 @@ This file tracks which tasks from `DEPLOYMENT-TODO.md` have been completed.
 - [x] **4 Distributed Rate-Limiter (Redis Lua)**
 - [x] **5 Redis Streams Event Bus**
 
+- [x] **11 Dockerfile (non-root + healthcheck)**
+- [x] **12 Docker-Compose Stack (dev / single VM)**
+- [x] **13 systemd Service (bare metal)**

--- a/README.md
+++ b/README.md
@@ -186,7 +186,9 @@ The plugin system loads modules listed in `XYTE_PLUGINS`, allowing hooks on even
 
 ### Running Tests
 
+Activate the provided virtual environment first:
 ```bash
+source venv/bin/activate
 pytest
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,37 @@
+version: "3.9"
+services:
+  mcp:
+    image: ghcr.io/xyte/mcp:latest
+    ports: ["8000:8000"]
+    environment:
+      REDIS_URL: "redis://redis:6379/0"
+      DATABASE_URL: "postgresql+asyncpg://mcp:pass@pg/mcp"
+      LOG_LEVEL: "INFO"
+    depends_on: [redis, pg]
+    restart: always
+
+  redis:
+    image: redis:7
+    command: ["--save","60","1","--loglevel","warning"]
+    volumes: ["redis:/data"]
+
+  pg:
+    image: postgres:15
+    environment:
+      POSTGRES_DB: mcp
+      POSTGRES_USER: mcp
+      POSTGRES_PASSWORD: pass
+    volumes: ["pg:/var/lib/postgresql/data"]
+
+  worker:
+    image: ghcr.io/xyte/mcp:latest
+    command: celery -A xyte_mcp_alpha.celery_app worker -Q long -c 2
+    environment:
+      REDIS_URL: "redis://redis:6379/0"
+      DATABASE_URL: "postgresql+asyncpg://mcp:pass@pg/mcp"
+    depends_on: [redis, pg]
+    restart: always
+
+volumes:
+  redis:
+  pg:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements/prod.txt .
+RUN pip install --no-cache-dir -r prod.txt
+COPY src ./src
+RUN useradd -m mcp
+USER mcp
+EXPOSE 8000
+HEALTHCHECK CMD curl -f http://localhost:8000/healthz || exit 1
+CMD ["uvicorn", "xyte_mcp_alpha.server:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/ops/mcp.service
+++ b/ops/mcp.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=XYTE MCP Service
+After=network.target redis.service postgresql.service
+
+[Service]
+User=mcp
+WorkingDirectory=/opt/mcp
+Environment="REDIS_URL=redis://127.0.0.1:6379/0"
+Environment="DATABASE_URL=postgresql+asyncpg://mcp:pass@127.0.0.1/mcp"
+ExecStart=/opt/mcp-venv/bin/uvicorn xyte_mcp_alpha.server:app --host 0.0.0.0 --port 8000
+Restart=always
+LimitNOFILE=65536
+
+[Install]
+WantedBy=multi-user.target

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,0 +1,6 @@
+-r prod.txt
+pytest>=8.2
+ruff>=0.4
+pyright>=1.1
+safety>=3.2
+mkdocs-material>=9.5

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,0 +1,17 @@
+mcp[cli]>=1.1.0
+starlette>=0.36
+uvicorn[standard]>=0.29
+python-multipart>=0.0.9
+passlib[bcrypt]>=1.7
+httpx>=0.27.0
+cachetools>=5.3.0
+redis[async]>=5.0
+sqlmodel>=0.0.12
+asyncpg>=0.29
+celery[redis]>=5.3
+pyyaml>=6.0
+pyjwt>=2.8
+prometheus-client>=0.19.0
+opentelemetry-sdk>=1.25.0
+python-dotenv>=1.0.0
+pydantic>=2.0.0

--- a/tests/test_deployment_files.py
+++ b/tests/test_deployment_files.py
@@ -1,0 +1,31 @@
+import os
+import unittest
+import yaml
+
+class DeploymentFilesTestCase(unittest.TestCase):
+    def test_dockerfile_healthcheck(self):
+        path = os.path.join('docker', 'Dockerfile')
+        self.assertTrue(os.path.exists(path))
+        with open(path) as f:
+            data = f.read()
+        self.assertIn('HEALTHCHECK', data)
+        self.assertIn('uvicorn', data)
+
+    def test_compose_file(self):
+        path = 'docker-compose.yml'
+        self.assertTrue(os.path.exists(path))
+        with open(path) as f:
+            config = yaml.safe_load(f)
+        self.assertIn('services', config)
+        self.assertIn('mcp', config['services'])
+        self.assertEqual(config['services']['mcp']['ports'], ['8000:8000'])
+
+    def test_systemd_service(self):
+        path = os.path.join('ops', 'mcp.service')
+        self.assertTrue(os.path.exists(path))
+        with open(path) as f:
+            data = f.read()
+        self.assertIn('ExecStart', data)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add Dockerfile for non-root container with healthcheck
- define docker-compose stack for local deployments
- provide systemd unit file
- clarify README instructions for running tests
- mark deployment tasks as completed
- ensure deployment config files exist via new tests

## Testing
- `ruff check src tests`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683ef17d077c8325986ca1cb6d35f2f7