### PR TITLE
Add deployment utilities, Helm improvements, docs

### DIFF
--- a/docs/REAL_LIFE_USAGE.md
+++ b/docs/REAL_LIFE_USAGE.md
@@ -1,0 +1,21 @@
+# Real-Life Usage Examples
+
+## Curl
+
+```bash
+curl -H "X-XYTE-API-KEY: XYTE_live_ABC..." \
+     -H "Content-Type: application/json" \
+     -d '{"method":"tools/call","params":{"name":"start_meeting_room_preset","arguments":{"room":"Board"}}, "id":1,"jsonrpc":"2.0"}' \
+     https://mcp.example.com
+```
+
+## Claude Desktop `host.json`
+
+```json
+{
+  "url": "https://mcp.example.com",
+  "headers": {
+    "x-xyte-api-key": "XYTE_live_ABC..."
+  }
+}
+```

--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -8,3 +8,5 @@ data:
   XYTE_ENV: {{ .Values.env.XYTE_ENV | quote }}
   XYTE_RATE_LIMIT: {{ .Values.env.XYTE_RATE_LIMIT | quote }}
   MCP_INSPECTOR_PORT: {{ .Values.env.MCP_INSPECTOR_PORT | quote }}
+  REDIS_URL: {{ .Values.env.REDIS_URL | quote }}
+  DATABASE_URL: {{ .Values.env.DATABASE_URL | quote }}

--- a/helm/templates/hpa.yaml
+++ b/helm/templates/hpa.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.hpa.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: xyte-mcp
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: xyte-mcp
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 80
+{{- end }}

--- a/helm/templates/ingress.yaml
+++ b/helm/templates/ingress.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: xyte-mcp
+spec:
+  rules:
+  - host: {{ index .Values.ingress.hosts 0 }}
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: xyte-mcp
+            port:
+              number: {{ .Values.service.port }}
+  tls:
+{{- range .Values.ingress.tls }}
+  - hosts:
+{{- range .hosts }}
+    - {{ . }}
+{{- end }}
+    secretName: {{ .secretName }}
+{{- end }}
+{{- end }}

--- a/helm/templates/worker-deployment.yaml
+++ b/helm/templates/worker-deployment.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.worker.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: xyte-mcp-worker
+spec:
+  replicas: {{ .Values.worker.replicas }}
+  selector:
+    matchLabels:
+      app: xyte-mcp-worker
+  template:
+    metadata:
+      labels:
+        app: xyte-mcp-worker
+    spec:
+      containers:
+      - name: worker
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        command: ["celery", "-A", "xyte_mcp_alpha.celery_app", "worker", "-Q", "long", "-c", "2"]
+        env:
+        - name: XYTE_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: xyte-secrets
+              key: api_key
+        envFrom:
+        - configMapRef:
+            name: xyte-config
+        resources:
+{{ toYaml .Values.worker.resources | indent 10 }}
+{{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -15,3 +15,27 @@ env:
   XYTE_ENV: "prod"
   XYTE_RATE_LIMIT: "60"
   MCP_INSPECTOR_PORT: "8080"
+  REDIS_URL: "redis://xyte-redis-master.data.svc:6379/0"
+  DATABASE_URL: "postgresql+asyncpg://mcp:pass@xyte-pg.data.svc/mcp"
+
+hpa:
+  enabled: true
+  minReplicas: 1
+  maxReplicas: 4
+
+worker:
+  enabled: true
+  replicas: 2
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+
+ingress:
+  enabled: true
+  hosts:
+    - mcp.example.com
+  tls:
+    - hosts:
+        - mcp.example.com
+      secretName: mcp-tls

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -8,3 +8,5 @@ data:
   XYTE_ENV: "prod"
   XYTE_RATE_LIMIT: "60"
   MCP_INSPECTOR_PORT: "8080"
+  REDIS_URL: "redis://xyte-redis-master.data.svc:6379/0"
+  DATABASE_URL: "postgresql+asyncpg://mcp:pass@xyte-pg.data.svc/mcp"

--- a/k8s/hpa.yaml
+++ b/k8s/hpa.yaml
@@ -1,0 +1,18 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: xyte-mcp
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: xyte-mcp
+  minReplicas: 1
+  maxReplicas: 4
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 80

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: xyte-mcp
+spec:
+  rules:
+  - host: mcp.example.com
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: xyte-mcp
+            port:
+              number: 80
+  tls:
+  - hosts:
+    - mcp.example.com
+    secretName: mcp-tls

--- a/k8s/worker-deployment.yaml
+++ b/k8s/worker-deployment.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: xyte-mcp-worker
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: xyte-mcp-worker
+  template:
+    metadata:
+      labels:
+        app: xyte-mcp-worker
+    spec:
+      containers:
+      - name: worker
+        image: xyte-mcp:latest
+        command: ["celery", "-A", "xyte_mcp_alpha.celery_app", "worker", "-Q", "long", "-c", "2"]
+        env:
+        - name: XYTE_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: xyte-secrets
+              key: api_key
+        envFrom:
+        - configMapRef:
+            name: xyte-config
+        resources:
+          requests:
+            cpu: 100m
+            memory: 256Mi

--- a/ops/pg_backup.sh
+++ b/ops/pg_backup.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+DATE=$(date +%F)
+pg_dump -U mcp -h pg -d mcp | gzip > /backups/mcp_$DATE.sql.gz

--- a/prometheus/alerts.yaml
+++ b/prometheus/alerts.yaml
@@ -1,0 +1,10 @@
+groups:
+- name: mcp
+  rules:
+  - alert: MCPHighErrorRate
+    expr: sum(rate(mcp_tool_errors_total[5m])) / sum(rate(mcp_tool_invocations_total[5m])) > 0.05
+    for: 5m
+    labels:
+      severity: critical
+    annotations:
+      summary: "MCP error rate >5%"

--- a/src/xyte_mcp_alpha/config.py
+++ b/src/xyte_mcp_alpha/config.py
@@ -25,6 +25,7 @@ class Settings(BaseSettings):
     xyte_api_mapping: str | None = Field(default=None, alias="XYTE_API_MAPPING")
     xyte_hooks_module: str | None = Field(default=None, alias="XYTE_HOOKS_MODULE")
     log_level: str = Field(default="INFO", alias="XYTE_LOG_LEVEL")
+    enable_swagger: bool = Field(default=False, alias="XYTE_ENABLE_SWAGGER")
 
 
 @lru_cache()

--- a/src/xyte_mcp_alpha/server.py
+++ b/src/xyte_mcp_alpha/server.py
@@ -39,6 +39,18 @@ audit_logger.setLevel(logging.INFO)
 app = Starlette()
 app.add_middleware(RequireXyteKey)
 
+# Optional Swagger UI using FastAPI
+settings = get_settings()
+if settings.enable_swagger:
+    try:
+        from fastapi import FastAPI
+    except ModuleNotFoundError:  # pragma: no cover - optional dependency
+        logging.getLogger(__name__).warning("FastAPI not installed; Swagger disabled")
+    else:
+        fast = FastAPI(openapi_url="/openapi.json", docs_url="/docs")
+        fast.mount("", app)
+        app = fast
+
 # Initialize MCP server
 mcp = FastMCP("Xyte Organization MCP Server")
 

--- a/tests/test_deployment_assets.py
+++ b/tests/test_deployment_assets.py
@@ -1,0 +1,51 @@
+import os
+import importlib
+import yaml
+import httpx
+import pytest
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def test_pg_backup_script_exists():
+    path = os.path.join('ops', 'pg_backup.sh')
+    assert os.path.isfile(path)
+    with open(path, 'r') as f:
+        first = f.readline().strip()
+    assert first == '#!/usr/bin/env bash'
+
+
+def test_prometheus_alerts_exists():
+    assert os.path.isfile(os.path.join('prometheus', 'alerts.yaml'))
+
+
+def test_real_life_examples_doc():
+    assert os.path.isfile(os.path.join('docs', 'REAL_LIFE_USAGE.md'))
+
+
+def test_helm_values_keys():
+    with open('helm/values.yaml') as f:
+        values = yaml.safe_load(f)
+    assert 'worker' in values
+    assert 'hpa' in values
+    assert 'ingress' in values
+    assert 'REDIS_URL' in values['env']
+    assert 'DATABASE_URL' in values['env']
+
+
+@pytest.mark.anyio
+async def test_swagger_docs(monkeypatch):
+    if importlib.util.find_spec("fastapi") is None:
+        pytest.skip("fastapi not installed")
+    monkeypatch.setenv('XYTE_ENABLE_SWAGGER', '1')
+    import xyte_mcp_alpha.server as server
+    importlib.reload(server)
+    transport = httpx.ASGITransport(app=server.app)
+    async with httpx.AsyncClient(transport=transport, base_url='http://t') as c:
+        r = await c.get('/docs')
+    assert r.status_code == 200


### PR DESCRIPTION
## Summary
- add optional Swagger UI via `XYTE_ENABLE_SWAGGER`
- expand Helm values and templates (HPA, ingress, worker)
- provide Kubernetes manifests matching chart
- include postgres backup script and Prometheus alerts
- add real-life usage docs
- test new deployment assets
- handle missing FastAPI dependency

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683ef1a5586483258f937973cc2e7397