### PR TITLE
Remove XYTE_USER_TOKEN support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,8 +2,6 @@
 XYTE_API_KEY=your-api-key-here
 # Optional: Override the API base URL (defaults to production)
 # XYTE_BASE_URL=https://hub.xyte.io/core/v1/organization
-# Optional: per-user token overriding XYTE_API_KEY
-# XYTE_USER_TOKEN=override-token
 # Optional: cache TTL in seconds
 # XYTE_CACHE_TTL=60
 # Optional: set environment name

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,12 +12,11 @@ This guide explains how agents (human or AI) can interact with the Xyte MCP serv
 Before using any MCP capabilities, the agent (or the environment hosting the agent) must authenticate with Xyte’s API via the MCP server’s configuration:
 
 * **API Key:** Set the environment variable `XYTE_API_KEY` to your organization’s API key. This is required for all operations. The server uses this key to authorize requests to Xyte’s cloud API.
-* **User Token (Optional):** If you want the server to act on behalf of a specific user (for user-scoped data), provide a `XYTE_USER_TOKEN`. If this token is set, it will override the API key for relevant calls. In other words, the MCP server will use the user token instead of the org API key when making API requests if the token is available. (You can also pass a user token at runtime for specific calls as needed.)
 * **Base URL & Other Config:** By default, the server targets Xyte’s production API base URL. You can override `XYTE_BASE_URL` for testing, though typically not needed. Other optional settings include `XYTE_CACHE_TTL` (caching duration for certain lookups), `XYTE_RATE_LIMIT` (to tune the rate limit threshold), and `XYTE_ENV` (environment name). See the provided `.env.example` for reference.
 
 **Usage:** Typically, you will provide these credentials via a `.env` file or environment variables before launching the MCP server. The server reads them on startup. Once configured, agents do not need to send authentication headers on each request – the server handles auth with Xyte internally using the provided key/token.
 
-Ensure that the API key and token remain secure. They grant control over your organization’s devices and data. If using a user token, restrict its scope appropriately (e.g. read-only vs. full control depending on use case).
+Ensure that the API key remains secure, as it grants control over your organization’s devices and data.
 
 ## Tool Invocation
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ An MCP (Model Context Protocol) server that provides access to the Xyte Organiza
 
 1. Ensure Python 3.11+ is installed and clone the repo.
 2. Create a virtualenv and install the project: `pip install -e .`.
-3. Copy `.env.example` to `.env` and set `XYTE_API_KEY` (and optional `XYTE_USER_TOKEN`).
+3. Copy `.env.example` to `.env` and set `XYTE_API_KEY`.
 4. Run the server with `serve` or `python -m xyte_mcp_alpha`.
 ## Setup
 
@@ -94,7 +94,6 @@ XYTE_API_KEY=your-actual-api-key-here
 
 3. Configure optional variables as needed:
    - `XYTE_BASE_URL` - override the Xyte API base URL.
-   - `XYTE_USER_TOKEN` - user-scoped token if acting on behalf of a specific user.
    - `XYTE_RATE_LIMIT` - requests per minute limit (defaults to 60).
    - `XYTE_PLUGINS` - comma-separated list of plugin modules to load.
 
@@ -232,7 +231,6 @@ example dashboard).
 - `XYTE_API_KEY` (required) - Your Xyte organization API key
 - `XYTE_OAUTH_TOKEN` (optional) - OAuth2 access token instead of API key
 - `XYTE_BASE_URL` (optional) - Override the API base URL (defaults to production)
-- `XYTE_USER_TOKEN` (optional) - Per-user token to override the global API key
 - `XYTE_CACHE_TTL` (optional) - TTL in seconds for cached API responses (default 60)
 - `XYTE_ENV` (optional) - Deployment environment name (`dev`, `staging`, `prod`)
 - `XYTE_RATE_LIMIT` (optional) - Maximum MCP requests per minute (default 60)
@@ -289,7 +287,7 @@ Destructive tools like `send_command` and `delete_device` now accept a `dry_run`
 
 ## Troubleshooting
 
-If you receive `unauthorized` errors, verify that `XYTE_API_KEY` is correct and has the required permissions. Use `XYTE_USER_TOKEN` when acting on behalf of a specific user. Increase `XYTE_RATE_LIMIT` if you hit rate limit errors during development.
+If you receive `unauthorized` errors, verify that `XYTE_API_KEY` is correct and has the required permissions. Increase `XYTE_RATE_LIMIT` if you hit rate limit errors during development.
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,7 +15,7 @@ If you believe you have found a security vulnerability, please responsibly discl
 
 ## Token and Secret Management
 
-- **Environment files.** Store secrets such as `XYTE_API_KEY` or `XYTE_USER_TOKEN` in an `.env` file or as environment variables. Never commit secrets to version control.
+- **Environment files.** Store secrets such as `XYTE_API_KEY` in an `.env` file or as environment variables. Never commit secrets to version control.
 - **Secret rotation.** Rotate API keys and tokens on a regular schedule. When rotating, update the `.env` file or your secret store and restart the server so new credentials take effect.
 - **Centralized secret stores.** In production, prefer a dedicated secrets manager (like HashiCorp Vault or your cloud provider's solution) over plain files.
 

--- a/docs/HELM_VALUES.md
+++ b/docs/HELM_VALUES.md
@@ -12,7 +12,6 @@ This document describes the configurable values available when deploying the MCP
 | `service.port` | Service port exposed by the container | `80` |
 | `env.XYTE_API_KEY` | Xyte organization API key | `""` (must be set) |
 | `env.XYTE_BASE_URL` | Base URL for the Xyte API | `https://hub.xyte.io/core/v1/organization` |
-| `env.XYTE_USER_TOKEN` | Optional per-user token | `""` |
 | `env.XYTE_CACHE_TTL` | Cache TTL for API responses | `60` |
 | `env.XYTE_ENV` | Deployment environment label | `prod` |
 | `env.XYTE_RATE_LIMIT` | Requests per minute allowed by the MCP | `60` |

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -10,7 +10,6 @@ service:
 env:
   XYTE_API_KEY: ""
   XYTE_BASE_URL: "https://hub.xyte.io/core/v1/organization"
-  XYTE_USER_TOKEN: ""
   XYTE_CACHE_TTL: "60"
   XYTE_ENV: "prod"
   XYTE_RATE_LIMIT: "60"

--- a/src/xyte_mcp_alpha/config.py
+++ b/src/xyte_mcp_alpha/config.py
@@ -13,7 +13,6 @@ class Settings(BaseSettings):
     xyte_base_url: str = Field(
         default="https://hub.xyte.io/core/v1/organization", alias="XYTE_BASE_URL"
     )
-    xyte_user_token: str | None = Field(default=None, alias="XYTE_USER_TOKEN")
     xyte_cache_ttl: int = Field(default=60, alias="XYTE_CACHE_TTL")
     environment: str = Field(default="prod", alias="XYTE_ENV")
     rate_limit_per_minute: int = Field(default=60, alias="XYTE_RATE_LIMIT")
@@ -43,8 +42,8 @@ def reload_settings() -> None:
 
 def validate_settings(settings: Settings) -> None:
     """Validate critical configuration values and raise ``ValueError`` if invalid."""
-    if not (settings.xyte_api_key or settings.xyte_oauth_token or settings.xyte_user_token):
-        raise ValueError("XYTE_API_KEY, XYTE_OAUTH_TOKEN, or XYTE_USER_TOKEN must be set")
+    if not (settings.xyte_api_key or settings.xyte_oauth_token):
+        raise ValueError("XYTE_API_KEY or XYTE_OAUTH_TOKEN must be set")
     if settings.rate_limit_per_minute <= 0:
         raise ValueError("XYTE_RATE_LIMIT must be positive")
     if settings.xyte_cache_ttl <= 0:

--- a/src/xyte_mcp_alpha/deps.py
+++ b/src/xyte_mcp_alpha/deps.py
@@ -13,7 +13,7 @@ async def get_client(user_token: Optional[str] = None) -> AsyncIterator[XyteAPIC
         user_token: Optional token to use instead of the default API key.
     """
     settings = get_settings()
-    api_key = user_token or settings.xyte_user_token or settings.xyte_api_key
+    api_key = user_token or settings.xyte_api_key
     client = XyteAPIClient(api_key=api_key, base_url=settings.xyte_base_url)
     try:
         yield client

--- a/src/xyte_mcp_alpha/server.py
+++ b/src/xyte_mcp_alpha/server.py
@@ -84,8 +84,6 @@ async def config_endpoint(request: Request) -> JSONResponse:
 
     cfg = settings.model_dump()
     cfg["xyte_api_key"] = "***"
-    if cfg.get("xyte_user_token"):
-        cfg["xyte_user_token"] = "***"
     return JSONResponse({"config": cfg})
 
 
@@ -93,10 +91,12 @@ async def config_endpoint(request: Request) -> JSONResponse:
 async def webhook(req: Request) -> JSONResponse:
     """Receive external events and enqueue them for streaming."""
     payload = await req.json()
-    await push_event({
-        "type": payload.get("type", "unknown"),
-        "data": payload.get("data", {}),
-    })
+    await push_event(
+        {
+            "type": payload.get("type", "unknown"),
+            "data": payload.get("data", {}),
+        }
+    )
     return JSONResponse({"queued": True})
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,21 +7,20 @@ from pydantic_settings import SettingsConfigDict
 
 class SettingsTestCase(unittest.TestCase):
     def test_load_settings_from_env(self):
-        os.environ['XYTE_API_KEY'] = 'abc'
-        os.environ['XYTE_BASE_URL'] = 'http://test'
-        os.environ['XYTE_CACHE_TTL'] = '30'
-        os.environ['XYTE_RATE_LIMIT'] = '10'
+        os.environ["XYTE_API_KEY"] = "abc"
+        os.environ["XYTE_BASE_URL"] = "http://test"
+        os.environ["XYTE_CACHE_TTL"] = "30"
+        os.environ["XYTE_RATE_LIMIT"] = "10"
         get_settings.cache_clear()
         s = Settings()
-        self.assertEqual(s.xyte_api_key, 'abc')
-        self.assertEqual(s.xyte_base_url, 'http://test')
+        self.assertEqual(s.xyte_api_key, "abc")
+        self.assertEqual(s.xyte_base_url, "http://test")
         self.assertEqual(s.xyte_cache_ttl, 30)
         self.assertEqual(s.rate_limit_per_minute, 10)
 
     def test_missing_required_api_key(self):
-        os.environ.pop('XYTE_API_KEY', None)
-        os.environ.pop('XYTE_OAUTH_TOKEN', None)
-        os.environ.pop('XYTE_USER_TOKEN', None)
+        os.environ.pop("XYTE_API_KEY", None)
+        os.environ.pop("XYTE_OAUTH_TOKEN", None)
         get_settings.cache_clear()
 
         # Create a settings class with no env file
@@ -33,5 +32,5 @@ class SettingsTestCase(unittest.TestCase):
             validate_settings(settings)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- drop `xyte_user_token` field from Settings and client fallback
- update `/config` endpoint masking
- purge `XYTE_USER_TOKEN` from docs and environment templates
- update security docs and AGENTS guide
- adjust unit tests

## Testing
- `black src/xyte_mcp_alpha/config.py src/xyte_mcp_alpha/deps.py src/xyte_mcp_alpha/server.py tests/test_config.py`
- `ruff check src/xyte_mcp_alpha tests`
- `mypy src/xyte_mcp_alpha tests` *(fails: redis.asyncio missing)*
- `pytest -q` *(fails: ModuleNotFoundError: httpx)*

------
https://chatgpt.com/codex/tasks/task_e_683efffb40a083259ccdef61227d5651