### PR TITLE
Fix tests with environment API key

### DIFF
--- a/tests/test_auth_middleware.py
+++ b/tests/test_auth_middleware.py
@@ -1,5 +1,8 @@
+import os
 import pytest
 import httpx
+
+os.environ.pop("XYTE_API_KEY", None)
 
 from xyte_mcp_alpha import http as http_mod
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,6 +1,10 @@
+import os
 import unittest
 import httpx
 import pytest
+
+os.environ.pop("XYTE_API_KEY", None)
+
 from xyte_mcp_alpha import http as http_mod
 
 from xyte_mcp_alpha.utils import handle_api, MCPError


### PR DESCRIPTION
## Summary
- ensure `XYTE_API_KEY` is cleared before importing HTTP app in tests
- update `test_auth_middleware` and `test_errors` to remove env key

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f36fbaa9883258fee3cd4e371ff41