### PR TITLE
Implement request-aware Xyte client

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -32,9 +32,9 @@ No branch-flow instructions are included—just the work itself.
 
 | Step | Action                                                                                                                                               | Rationale                                                                        |
 | ---- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
-| 3.1  | Extend `deps.get_client()` signature to accept `Request`; resolve key:  <br>`key = request.state.xyte_key or settings.xyte_api_key`.                 | Single function now covers both modes—call-sites don’t need to think about auth. |
-| 3.2  | Refactor every resource/tool/task that currently calls `get_client()` to pass `request` (use dependency injection where FastAPI routes are defined). | Keeps call signatures explicit but lightweight; no hidden globals.               |
-| 3.3  | Delete any accidental use of `settings.xyte_api_key` elsewhere in code except as the single-tenant fallback.                                         | Guarantees header override always wins in multi-tenant mode.                     |
+| [x] 3.1 | Extend `deps.get_client()` signature to accept `Request`; resolve key:  <br>`key = request.state.xyte_key or settings.xyte_api_key`.                 | Single function now covers both modes—call-sites don’t need to think about auth. |
+| [x] 3.2 | Refactor every resource/tool/task that currently calls `get_client()` to pass `request` (use dependency injection where FastAPI routes are defined). | Keeps call signatures explicit but lightweight; no hidden globals.               |
+| [x] 3.3 | Delete any accidental use of `settings.xyte_api_key` elsewhere in code except as the single-tenant fallback.                                         | Guarantees header override always wins in multi-tenant mode.                     |
 
 ---
 

--- a/src/xyte_mcp_alpha/deps.py
+++ b/src/xyte_mcp_alpha/deps.py
@@ -1,19 +1,24 @@
 from contextlib import asynccontextmanager
 from typing import AsyncIterator, Optional
+from starlette.requests import Request
+from .logging_utils import request_var
 
 from .client import XyteAPIClient
 from .config import get_settings
 
 
 @asynccontextmanager
-async def get_client(user_token: Optional[str] = None) -> AsyncIterator[XyteAPIClient]:
+async def get_client(request: Optional[Request] = None) -> AsyncIterator[XyteAPIClient]:
     """Yield a new API client instance for a request.
 
     Args:
-        user_token: Optional token to use instead of the default API key.
+        request: Current HTTP request providing the authorization header.
     """
     settings = get_settings()
-    api_key = user_token or settings.xyte_api_key
+    if request is None:
+        request = request_var.get()
+    key = getattr(request.state, "xyte_key", None) if request else None
+    api_key = key or settings.xyte_api_key
     client = XyteAPIClient(api_key=api_key, base_url=settings.xyte_base_url)
     try:
         yield client

--- a/src/xyte_mcp_alpha/logging_utils.py
+++ b/src/xyte_mcp_alpha/logging_utils.py
@@ -4,6 +4,7 @@ import sys
 import time
 import uuid
 from contextvars import ContextVar
+from starlette.requests import Request
 from typing import Any, Callable, Awaitable
 from functools import wraps
 from prometheus_client import Histogram, Counter
@@ -21,6 +22,8 @@ import xyte_mcp_alpha.plugin as plugin
 
 # Context variable to store request ID for each incoming request
 request_id_var: ContextVar[str | None] = ContextVar("request_id", default=None)
+# Store the active Request object so downstream functions can access it
+request_var: ContextVar[Request | None] = ContextVar("request", default=None)
 
 # Prometheus metrics for HTTP and tool/resource handling
 HTTP_REQUEST_LATENCY = Histogram(
@@ -33,9 +36,7 @@ HTTP_REQUEST_COUNT = Counter(
     "HTTP request count",
     ["method", "path", "status"],
 )
-TOOL_LATENCY = Histogram(
-    "xyte_tool_latency_seconds", "Latency of tool handlers", ["tool"]
-)
+TOOL_LATENCY = Histogram("xyte_tool_latency_seconds", "Latency of tool handlers", ["tool"])
 RESOURCE_LATENCY = Histogram(
     "xyte_resource_latency_seconds",
     "Latency of resource handlers",
@@ -126,6 +127,8 @@ class RequestLoggingMiddleware:
 
         request_id = str(uuid.uuid4())
         token_ctx = request_id_var.set(request_id)
+        req = Request(scope, receive)
+        token_req = request_var.set(req)
         method = scope.get("method")
         path = scope.get("path")
         start = time.monotonic()
@@ -158,9 +161,7 @@ class RequestLoggingMiddleware:
                     status=status_code,
                     request_id=request_id,
                 )
-            if message["type"] == "http.response.body" and not message.get(
-                "more_body", False
-            ):
+            if message["type"] == "http.response.body" and not message.get("more_body", False):
                 duration = time.monotonic() - start
                 duration_ms = duration * 1000
                 log_json(
@@ -177,6 +178,7 @@ class RequestLoggingMiddleware:
             await self.app(scope, receive, send_wrapper)
         finally:
             request_id_var.reset(token_ctx)
+            request_var.reset(token_req)
 
 
 def instrument(

--- a/src/xyte_mcp_alpha/resources.py
+++ b/src/xyte_mcp_alpha/resources.py
@@ -7,80 +7,81 @@ from .utils import handle_api, validate_device_id, validate_ticket_id
 from .user import get_preferences
 
 
-async def list_devices() -> Dict[str, Any]:
+from starlette.requests import Request
+
+
+async def list_devices(request: Request) -> Dict[str, Any]:
     """Return all devices in the organization."""
-    async with get_client() as client:
+    async with get_client(request) as client:
         return await handle_api("get_devices", client.get_devices())
 
 
-async def list_device_commands(device_id: str) -> Dict[str, Any]:
+async def list_device_commands(request: Request, device_id: str) -> Dict[str, Any]:
     """List commands for a specific device."""
     device_id = validate_device_id(device_id)
-    async with get_client() as client:
+    async with get_client(request) as client:
         return await handle_api("get_device_commands", client.get_commands(device_id))
 
 
-async def list_device_histories(device_id: str) -> Dict[str, Any]:
+async def list_device_histories(request: Request, device_id: str) -> Dict[str, Any]:
     """Return history records for a device."""
     device_id = validate_device_id(device_id)
-    async with get_client() as client:
+    async with get_client(request) as client:
         return await handle_api(
             "get_device_histories", client.get_device_histories(device_id=device_id)
         )
 
 
-async def device_status(device_id: str) -> Dict[str, Any]:
+async def device_status(request: Request, device_id: str) -> Dict[str, Any]:
     """Return status information for a single device."""
     device_id = validate_device_id(device_id)
-    async with get_client() as client:
+    async with get_client(request) as client:
         return await handle_api("get_device", client.get_device(device_id))
 
 
-async def device_logs(device_id: str) -> Dict[str, Any]:
+async def device_logs(request: Request, device_id: str) -> Dict[str, Any]:
     """Return recent logs for a device (sample resource)."""
     device_id = validate_device_id(device_id)
     # Placeholder implementation
     return {"device_id": device_id, "logs": ["log entry 1", "log entry 2"]}
 
 
-async def organization_info(device_id: str) -> Dict[str, Any]:
+async def organization_info(request: Request, device_id: str) -> Dict[str, Any]:
     """Fetch organization information for a device."""
     device_id = validate_device_id(device_id)
-    async with get_client() as client:
-        return await handle_api(
-            "get_organization_info", client.get_organization_info(device_id)
-        )
+    async with get_client(request) as client:
+        return await handle_api("get_organization_info", client.get_organization_info(device_id))
 
 
-async def list_incidents() -> Dict[str, Any]:
+async def list_incidents(request: Request) -> Dict[str, Any]:
     """List current incidents."""
-    async with get_client() as client:
+    async with get_client(request) as client:
         return await handle_api("get_incidents", client.get_incidents())
 
 
-async def list_tickets() -> Dict[str, Any]:
+async def list_tickets(request: Request) -> Dict[str, Any]:
     """List all support tickets."""
-    async with get_client() as client:
+    async with get_client(request) as client:
         return await handle_api("get_tickets", client.get_tickets())
 
 
-async def get_ticket(ticket_id: str) -> Dict[str, Any]:
+async def get_ticket(request: Request, ticket_id: str) -> Dict[str, Any]:
     """Retrieve a single ticket by ID."""
     ticket_id = validate_ticket_id(ticket_id)
-    async with get_client() as client:
+    async with get_client(request) as client:
         return await handle_api("get_ticket", client.get_ticket(ticket_id))
 
 
-async def get_user_preferences(user_token: str) -> Dict[str, Any]:
+async def get_user_preferences(request: Request, user_token: str) -> Dict[str, Any]:
     """Return stored preferences for a specific user."""
     prefs = get_preferences(user_token)
     return prefs.model_dump()
 
 
-async def list_user_devices(user_token: str) -> Any:
+async def list_user_devices(request: Request, user_token: str) -> Any:
     """List devices filtered by a user's preferred devices."""
     prefs = get_preferences(user_token)
-    async with get_client(user_token) as client:
+    async with get_client(request) as client:
         devices = await handle_api("get_devices", client.get_devices())
 
     device_list = devices.get("devices", devices)
@@ -91,4 +92,3 @@ async def list_user_devices(user_token: str) -> Any:
     else:
         devices = device_list
     return devices
-

--- a/src/xyte_mcp_alpha/tools/presets.py
+++ b/src/xyte_mcp_alpha/tools/presets.py
@@ -12,7 +12,8 @@ async def start_meeting_room_preset(
     """Power on and configure all devices for the given room preset."""
     f = Path(__file__).resolve().parent.parent / "presets" / f"{preset}.yaml"
     steps = yaml.safe_load(f.read_text())
-    async with get_client() as client:
+    req_obj = ctx.request_context.request if ctx else None
+    async with get_client(req_obj) as client:
         for step in steps:
             cmd = CommandRequest(
                 name=step["command"],

--- a/src/xyte_mcp_alpha/tools/ticket.py
+++ b/src/xyte_mcp_alpha/tools/ticket.py
@@ -12,26 +12,32 @@ from ..models import (
 )
 
 
-async def update_ticket(data: UpdateTicketRequest) -> Dict[str, Any]:
+from mcp.server.fastmcp.server import Context
+
+
+async def update_ticket(data: UpdateTicketRequest, ctx: Context | None = None) -> Dict[str, Any]:
     """Modify the title or description of a support ticket."""
-    async with get_client() as client:
+    req_obj = ctx.request_context.request if ctx else None
+    async with get_client(req_obj) as client:
         req = TicketUpdateRequest(title=data.title, description=data.description)
-        return await handle_api(
-            "update_ticket", client.update_ticket(data.ticket_id, req)
-        )
+        return await handle_api("update_ticket", client.update_ticket(data.ticket_id, req))
 
 
-async def mark_ticket_resolved(data: MarkTicketResolvedRequest) -> Dict[str, Any]:
+async def mark_ticket_resolved(
+    data: MarkTicketResolvedRequest, ctx: Context | None = None
+) -> Dict[str, Any]:
     """Mark a ticket as resolved."""
-    async with get_client() as client:
-        return await handle_api(
-            "mark_ticket_resolved", client.mark_ticket_resolved(data.ticket_id)
-        )
+    req_obj = ctx.request_context.request if ctx else None
+    async with get_client(req_obj) as client:
+        return await handle_api("mark_ticket_resolved", client.mark_ticket_resolved(data.ticket_id))
 
 
-async def send_ticket_message(data: SendTicketMessageRequest) -> Dict[str, Any]:
+async def send_ticket_message(
+    data: SendTicketMessageRequest, ctx: Context | None = None
+) -> Dict[str, Any]:
     """Post a new message to a ticket conversation."""
-    async with get_client() as client:
+    req_obj = ctx.request_context.request if ctx else None
+    async with get_client(req_obj) as client:
         req = TicketMessageRequest(message=data.message)
         return await handle_api(
             "send_ticket_message", client.send_ticket_message(data.ticket_id, req)

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -16,12 +16,13 @@ class DummyClient:
 def anyio_backend():
     return "asyncio"
 
+
 @pytest.mark.anyio
 async def test_start_meeting_room_preset(monkeypatch):
     client = DummyClient()
 
     @asynccontextmanager
-    async def fake_get_client():
+    async def fake_get_client(request=None):
         yield client
 
     monkeypatch.setattr("xyte_mcp_alpha.tools.presets.get_client", fake_get_client)

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,13 +1,18 @@
 import unittest
 
+from starlette.requests import Request
 from xyte_mcp_alpha import resources
 from xyte_mcp_alpha.utils import MCPError
 
+
 class ValidationTestCase(unittest.IsolatedAsyncioTestCase):
     async def test_invalid_device_id(self):
+        scope = {"type": "http", "path": "/", "method": "GET", "headers": []}
+        req = Request(scope, lambda: None)
         with self.assertRaises(MCPError) as cm:
-            await resources.list_device_commands("")
+            await resources.list_device_commands(req, "")
         self.assertEqual(cm.exception.code, "invalid_params")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- inject request object via contextvar for per-request API keys
- update `get_client` to resolve API key from request state
- refactor resources and tools to accept request
- register resource wrappers using current request
- mark client injection tasks complete and fix tests

## Testing
- `ruff format .`
- `ruff check .`
- `pyright` *(failed: KeyboardInterrupt)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f391a53f48325a8edbb6a50add2a3