### PR TITLE
Implement security and docs updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,4 @@ COPY README.md CHANGELOG.md ./
 
 USER appuser
 
-CMD ["serve"]
+CMD ["python", "-m", "xyte_mcp_alpha.http"]

--- a/README.md
+++ b/README.md
@@ -10,8 +10,14 @@ An MCP (Model Context Protocol) server that provides access to the Xyte Organiza
 
 1. Ensure Python 3.11+ is installed and clone the repo.
 2. Create a virtualenv and install the project: `pip install -e .`.
-3. Copy `.env.example` to `.env` and set `XYTE_API_KEY` if running in single-tenant mode (leave blank for hosted).
-4. Run the server with `serve` or `python -m xyte_mcp_alpha`.
+3. Copy `.env.example` to `.env` and then decide which mode to run:
+
+|                     | Local (Single-tenant) | Hosted (Multi-tenant) |
+|---------------------|----------------------|-----------------------|
+| Env vars            | `XYTE_API_KEY=<key>` | *(leave blank)*       |
+| Start server        | `python -m xyte_mcp_alpha.http` | `python -m xyte_mcp_alpha.http` |
+| Auth header         | none                 | `Authorization: <key>` |
+| Example curl        | `curl http://localhost:8080/v1/devices` | `curl -H "Authorization: $KEY" http://localhost:8080/v1/devices` |
 ## Setup
 
 ### Development

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,6 +8,7 @@ This document outlines best practices for keeping deployments of the Xyte MCP se
 - **Run the server in a minimal container.** Use the provided Dockerfile or a similarly hardened image and avoid running as the root user.
 - **Restrict network access.** Only expose the necessary ports and run the server behind your firewall when possible.
 - **Use least privilege.** API keys and user tokens should have the minimal permissions required for their task.
+- **Always use TLS.** Terminate HTTPS in front of the server to prevent credential leakage.
 
 ## Reporting Vulnerabilities
 

--- a/docs/API_USAGE.md
+++ b/docs/API_USAGE.md
@@ -1,0 +1,28 @@
+# API Usage Guide
+
+This document lists the available HTTP routes exposed by the MCP server.
+Each example uses JSON-RPC 2.0 over HTTP.
+
+## Resources
+
+| Purpose | Method & Route | Minimal Request | Example Response |
+|---------|---------------|-----------------|-----------------|
+| List devices | `GET /v1/devices` | n/a | `{ "devices": [...] }` |
+| Device status | `GET /v1/device/{id}/status` | n/a | `{ "status": "online" }` |
+
+## Tools
+
+| Purpose | Method & Route | Minimal Request |
+|---------|---------------|-----------------|
+| Send command | `POST /v1/tools/send_command` | `{ "device_id": "1", "name": "ping" }` |
+| Cancel command | `POST /v1/tools/cancel_command` | `{ "device_id": "1", "command_id": "abc" }` |
+
+Responses follow JSON-RPC conventions:
+
+```json
+{"jsonrpc":"2.0","result":{"ok":true},"id":1}
+```
+
+Common errors include:
+- `missing_xyte_key` – Authorization header required in multi-tenant mode.
+- `invalid_parameters` – request validation failed.

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -96,5 +96,8 @@ After installation the server will automatically load the plugin.
 Plugins may also call `register_payload_transform` to modify API responses before
 they reach the client.
 
+> **Warning**: plugins execute inside the server process. Only install plugins
+> from sources you trust.
+
 All listed plugins will be loaded at startup. Failures are logged but do not stop
 startup.

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -12,16 +12,21 @@ spec:
       labels:
         app: xyte-mcp
     spec:
+      securityContext:
+        runAsNonRoot: true
+        fsGroup: 1000
       containers:
       - name: xyte-mcp
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- if not .Values.multiTenant }}
         env:
         - name: XYTE_API_KEY
           valueFrom:
             secretKeyRef:
               name: xyte-secrets
               key: api_key
+        {{- end }}
         envFrom:
         - configMapRef:
             name: xyte-config

--- a/helm/templates/worker-deployment.yaml
+++ b/helm/templates/worker-deployment.yaml
@@ -13,16 +13,21 @@ spec:
       labels:
         app: xyte-mcp-worker
     spec:
+      securityContext:
+        runAsNonRoot: true
+        fsGroup: 1000
       containers:
       - name: worker
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         command: ["celery", "-A", "xyte_mcp_alpha.celery_app", "worker", "-Q", "long", "-c", "2"]
+        {{- if not .Values.multiTenant }}
         env:
         - name: XYTE_API_KEY
           valueFrom:
             secretKeyRef:
               name: xyte-secrets
               key: api_key
+        {{- end }}
         envFrom:
         - configMapRef:
             name: xyte-config

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,4 +1,5 @@
 replicaCount: 1
+multiTenant: false
 image:
   repository: xyte-mcp
   tag: latest

--- a/tests/test_log_redaction.py
+++ b/tests/test_log_redaction.py
@@ -1,0 +1,30 @@
+import io
+import logging
+import os
+import importlib
+import unittest
+from starlette.testclient import TestClient
+
+os.environ.setdefault("XYTE_API_KEY", "test")
+from xyte_mcp_alpha import http as http_mod
+
+class LogRedactionTestCase(unittest.TestCase):
+    def setUp(self):
+        importlib.reload(http_mod)
+        self.client = TestClient(http_mod.app)
+        self.stream = io.StringIO()
+        handler = logging.StreamHandler(self.stream)
+        logger = logging.getLogger("xyte_mcp_alpha")
+        logger.setLevel(logging.INFO)
+        logger.addHandler(handler)
+        self.handler = handler
+
+    def tearDown(self):
+        logging.getLogger("xyte_mcp_alpha").removeHandler(self.handler)
+
+    def test_header_redacted(self):
+        self.client.get("/v1/healthz", headers={"Authorization": "SECRETKEY"})
+        out = self.stream.getvalue()
+        assert "****" in out
+        assert "SECRETKEY" not in out
+


### PR DESCRIPTION
## Summary
- hide experimental device logs endpoint behind feature flag
- protect `/config` in hosted mode
- update Dockerfile entrypoint
- expand helm values and security settings
- overhaul README quickstart and deployment docs
- document API usage and plugin caution
- add log redaction test
- fix log redaction test configuration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f49aae3e48325be75b9ac7fd3049f