### PR TITLE
Implement optional API key mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # Xyte MCP Server Configuration
-# Leave empty for hosted multi-tenant mode
+# Leave blank for hosted mode
 XYTE_API_KEY=
 # Optional: Override the API base URL (defaults to production)
 # XYTE_BASE_URL=https://hub.xyte.io/core/v1/organization
@@ -9,5 +9,11 @@ XYTE_API_KEY=
 # XYTE_ENV=dev
 # Optional: max MCP requests per minute
 # XYTE_RATE_LIMIT=60
+# Comma-separated list of plugin modules to load
+# XYTE_PLUGINS=
+# OAuth token for multi-tenant deployments
+# XYTE_OAUTH_TOKEN=
+# User token for multi-tenant deployments
+# XYTE_USER_TOKEN=
 # Set to true to enable asynchronous tasks (Celery + DB/Redis required)
 ENABLE_ASYNC_TASKS=false

--- a/src/xyte_mcp_alpha/config.py
+++ b/src/xyte_mcp_alpha/config.py
@@ -52,9 +52,9 @@ def validate_settings(settings: Settings) -> None:
     """Validate critical configuration values and raise ``ValueError`` if invalid."""
     logger = logging.getLogger(__name__)
     if settings.multi_tenant:
-        logger.info("starting in multi-tenant mode")
+        logger.info("Running in multi-tenant mode")
     else:
-        logger.info("starting in single-tenant mode")
+        logger.info("Running in single-tenant mode")
     if settings.rate_limit_per_minute <= 0:
         raise ValueError("XYTE_RATE_LIMIT must be positive")
     if settings.xyte_cache_ttl <= 0:


### PR DESCRIPTION
## Summary
- log multi-tenant vs single-tenant startup mode
- document hosted mode env vars

## Testing
- `pytest tests/test_config.py::SettingsTestCase::test_multi_tenant_detection -q` *(fails: ModuleNotFoundError: No module named 'xyte_mcp_alpha')*

------
https://chatgpt.com/codex/tasks/task_e_683f5f1ecbc483259c8aef31ed809357