### PR TITLE
Implement multi-tenant auth middleware

### DIFF
--- a/src/xyte_mcp_alpha/auth.py
+++ b/src/xyte_mcp_alpha/auth.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import JSONResponse
+from starlette.requests import Request
+
+from .config import get_settings
+
+
+class AuthHeaderMiddleware(BaseHTTPMiddleware):
+    """Validate Authorization header depending on deployment mode."""
+
+    def __init__(self, app: any) -> None:  # type: ignore[override]
+        super().__init__(app)
+        self.settings = get_settings()
+
+    async def dispatch(self, request: Request, call_next):
+        if request.url.path in {
+            "/healthz",
+            "/readyz",
+            "/metrics",
+            "/v1/healthz",
+            "/v1/readyz",
+            "/v1/metrics",
+        }:
+            return await call_next(request)
+
+        header = request.headers.get("authorization")
+        env_key = self.settings.xyte_api_key
+
+        if env_key is None:
+            if not header or not header.strip():
+                return JSONResponse({"error": "missing_xyte_key"}, status_code=401)
+            request.state.xyte_key = header.strip()
+            return await call_next(request)
+
+        if header:
+            if header.strip() != env_key:
+                return JSONResponse({"error": "invalid_token"}, status_code=403)
+            request.state.xyte_key = header.strip()
+
+        return await call_next(request)

--- a/src/xyte_mcp_alpha/http.py
+++ b/src/xyte_mcp_alpha/http.py
@@ -12,7 +12,7 @@ from .server import get_server
 from .logging_utils import RequestLoggingMiddleware
 from .config import get_settings
 from .http_utils import RateLimitMiddleware
-from .auth_xyte import AuthHeaderMiddleware
+from .auth import AuthHeaderMiddleware
 from starlette.middleware.cors import CORSMiddleware
 
 
@@ -33,7 +33,6 @@ def build_openapi(app: Starlette) -> Dict[str, Any]:
 
 internal_app = get_server().streamable_http_app()
 internal_app.add_middleware(RequestLoggingMiddleware)
-internal_app.add_middleware(AuthHeaderMiddleware)
 settings = get_settings()
 internal_app.add_middleware(
     RateLimitMiddleware, limit_per_minute=settings.rate_limit_per_minute
@@ -44,6 +43,7 @@ internal_app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+internal_app.add_middleware(AuthHeaderMiddleware)
 
 routes = [Mount("/v1", app=internal_app)]
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,55 @@
+import os
+import importlib
+
+import httpx
+import pytest
+
+os.environ.pop("XYTE_API_KEY", None)
+
+from xyte_mcp_alpha import http as http_mod
+from xyte_mcp_alpha.config import reload_settings
+
+transport = httpx.ASGITransport(app=http_mod.app)
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+def no_network(monkeypatch):
+    async def noop(self):
+        return {}
+
+    monkeypatch.setattr(
+        "xyte_mcp_alpha.client.XyteAPIClient.get_devices", noop
+    )
+
+
+@pytest.mark.parametrize(
+    "env_key,header,expected",
+    [
+        (None, None, 401),
+        (None, "Bearer test", 200),
+        ("envkey", None, 200),
+        ("envkey", "wrong", 403),
+    ],
+)
+async def test_auth_modes(env_key, header, expected, monkeypatch):
+    if env_key is not None:
+        os.environ["XYTE_API_KEY"] = env_key
+    else:
+        os.environ.pop("XYTE_API_KEY", None)
+    reload_settings()
+    importlib.reload(http_mod)
+    transport2 = httpx.ASGITransport(app=http_mod.app)
+    headers = {"Authorization": header} if header else None
+    async with httpx.AsyncClient(transport=transport2, base_url="http://t") as c:
+        r = await c.get("/v1/devices", headers=headers)
+    assert r.status_code == expected
+    os.environ.pop("XYTE_API_KEY", None)
+    reload_settings()
+    importlib.reload(http_mod)


### PR DESCRIPTION
## Summary
- add `AuthHeaderMiddleware` implementing per-request API key logic
- wire middleware after CORS handling
- add auth integration tests

## Testing
- `venv/bin/pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f5e614f688325b2824864917dafb0