### PR TITLE
Implement helm secret tokens and health probes

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -19,16 +19,42 @@ spec:
       - name: xyte-mcp
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-        {{- if not .Values.multiTenant }}
         env:
+        {{- if not .Values.multiTenant }}
         - name: XYTE_API_KEY
           valueFrom:
             secretKeyRef:
               name: xyte-secrets
               key: api_key
         {{- end }}
+        {{- if .Values.env.XYTE_USER_TOKEN }}
+        - name: XYTE_USER_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: xyte-secrets
+              key: user_token
+        {{- end }}
+        {{- if .Values.env.XYTE_OAUTH_TOKEN }}
+        - name: XYTE_OAUTH_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: xyte-secrets
+              key: oauth_token
+        {{- end }}
         envFrom:
         - configMapRef:
             name: xyte-config
         ports:
         - containerPort: 8080
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10

--- a/helm/templates/secret.yaml
+++ b/helm/templates/secret.yaml
@@ -3,4 +3,12 @@ kind: Secret
 metadata:
   name: xyte-secrets
 stringData:
+{{- if .Values.env.XYTE_API_KEY }}
   api_key: {{ .Values.env.XYTE_API_KEY | quote }}
+{{- end }}
+{{- if .Values.env.XYTE_USER_TOKEN }}
+  user_token: {{ .Values.env.XYTE_USER_TOKEN | quote }}
+{{- end }}
+{{- if .Values.env.XYTE_OAUTH_TOKEN }}
+  oauth_token: {{ .Values.env.XYTE_OAUTH_TOKEN | quote }}
+{{- end }}

--- a/helm/templates/worker-deployment.yaml
+++ b/helm/templates/worker-deployment.yaml
@@ -20,13 +20,27 @@ spec:
       - name: worker
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         command: ["celery", "-A", "xyte_mcp_alpha.celery_app", "worker", "-Q", "long", "-c", "2"]
-        {{- if not .Values.multiTenant }}
         env:
+        {{- if not .Values.multiTenant }}
         - name: XYTE_API_KEY
           valueFrom:
             secretKeyRef:
               name: xyte-secrets
               key: api_key
+        {{- end }}
+        {{- if .Values.env.XYTE_USER_TOKEN }}
+        - name: XYTE_USER_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: xyte-secrets
+              key: user_token
+        {{- end }}
+        {{- if .Values.env.XYTE_OAUTH_TOKEN }}
+        - name: XYTE_OAUTH_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: xyte-secrets
+              key: oauth_token
         {{- end }}
         envFrom:
         - configMapRef:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -10,6 +10,8 @@ service:
 
 env:
   XYTE_API_KEY: ""
+  XYTE_USER_TOKEN: ""
+  XYTE_OAUTH_TOKEN: ""
   XYTE_BASE_URL: "https://hub.xyte.io/core/v1/organization"
   XYTE_CACHE_TTL: "60"
   XYTE_ENV: "prod"


### PR DESCRIPTION
## Summary
- add XYTE_USER_TOKEN and XYTE_OAUTH_TOKEN values
- map optional tokens as Kubernetes secrets and env vars
- add readiness & liveness probes using new HTTP entrypoint

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_683f5f3e6b0c8325b81cc2ab91dfb541