### PR TITLE
Implement async task strategy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,7 @@ XYTE_API_KEY=
 # XYTE_RATE_LIMIT=60
 # Set to true to enable asynchronous tasks (Celery + DB/Redis required)
 ENABLE_ASYNC_TASKS=false
+# Redis broker URL
+REDIS_URL=redis://localhost:6379/0
+# Celery result backend URL
+RESULT_BACKEND_URL=postgresql+asyncpg://mcp:pass@localhost/mcp

--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ An MCP (Model Context Protocol) server that provides access to the Xyte Organiza
 | Start server        | `python -m xyte_mcp_alpha.http` | `python -m xyte_mcp_alpha.http` |
 | Auth header         | none                 | `Authorization: <key>` |
 | Example curl        | `curl http://localhost:8080/v1/devices` | `curl -H "Authorization: $KEY" http://localhost:8080/v1/devices` |
+
+### Async Tasks
+
+By default the `send_command_async` tool runs commands synchronously and returns
+the result immediately.  Set `ENABLE_ASYNC_TASKS=true` and provide
+`REDIS_URL` along with `RESULT_BACKEND_URL` to enable Celery based background
+processing. When enabled, tasks survive restarts and workers can be scaled
+independently.
 ## Setup
 
 ### Development

--- a/docker-compose.celery.yaml
+++ b/docker-compose.celery.yaml
@@ -1,0 +1,27 @@
+version: '3.9'
+services:
+  mcp:
+    image: ghcr.io/xyte/mcp:latest
+    environment:
+      REDIS_URL: "redis://redis:6379/0"
+      RESULT_BACKEND_URL: "postgresql+asyncpg://mcp:pass@pg/mcp"
+      DATABASE_URL: "postgresql+asyncpg://mcp:pass@pg/mcp"
+      ENABLE_ASYNC_TASKS: 'true'
+    depends_on: [redis, pg]
+  redis:
+    image: redis:7
+  pg:
+    image: postgres:15
+    environment:
+      POSTGRES_DB: mcp
+      POSTGRES_USER: mcp
+      POSTGRES_PASSWORD: pass
+  worker:
+    image: ghcr.io/xyte/mcp:latest
+    command: celery -A xyte_mcp_alpha.celery_app worker -Q long -c 2
+    environment:
+      REDIS_URL: "redis://redis:6379/0"
+      RESULT_BACKEND_URL: "postgresql+asyncpg://mcp:pass@pg/mcp"
+      DATABASE_URL: "postgresql+asyncpg://mcp:pass@pg/mcp"
+      ENABLE_ASYNC_TASKS: 'true'
+    depends_on: [redis, pg]

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -71,6 +71,13 @@ services:
       ENABLE_ASYNC_TASKS: "true"
 ```
 
+### Async Task Strategy
+
+When `ENABLE_ASYNC_TASKS` is disabled the `send_command_async` tool simply
+executes the command synchronously and returns the result. Enabling the flag
+requires running Redis and a Celery worker (see sample `docker-compose.celery.yaml`)
+and tasks will persist across restarts.
+
 ## Multi-tenant Helm Values
 
 To deploy in hosted (multi-tenant) mode, set `multiTenant=true` and omit the API key.

--- a/helm/charts/celery/Chart.yaml
+++ b/helm/charts/celery/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: mcp-celery
+version: 0.1.0
+appVersion: "0.1.0"

--- a/helm/charts/celery/templates/redis.yaml
+++ b/helm/charts/celery/templates/redis.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mcp-redis
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mcp-redis
+  template:
+    metadata:
+      labels:
+        app: mcp-redis
+    spec:
+      containers:
+      - name: redis
+        image: {{ .Values.redis.image }}
+        args: ["--save","60","1","--loglevel","warning"]
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mcp-redis
+spec:
+  selector:
+    app: mcp-redis
+  ports:
+  - port: 6379
+    targetPort: 6379

--- a/helm/charts/celery/templates/worker.yaml
+++ b/helm/charts/celery/templates/worker.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mcp-worker
+spec:
+  replicas: {{ .Values.worker.replicas }}
+  selector:
+    matchLabels:
+      app: mcp-worker
+  template:
+    metadata:
+      labels:
+        app: mcp-worker
+    spec:
+      containers:
+      - name: worker
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        command: ["celery","-A","xyte_mcp_alpha.celery_app","worker","-Q","long","-c","2"]
+        env:
+        - name: REDIS_URL
+          value: "{{ .Values.redis.url | default \"redis://mcp-redis:6379/0\" }}"
+        - name: RESULT_BACKEND_URL
+          value: "{{ .Values.resultBackend | default \"postgresql+asyncpg://mcp:pass@pg/mcp\" }}"
+        - name: ENABLE_ASYNC_TASKS
+          value: "true"

--- a/helm/charts/celery/values.yaml
+++ b/helm/charts/celery/values.yaml
@@ -1,0 +1,7 @@
+worker:
+  replicas: 1
+image:
+  repository: xyte-mcp
+  tag: latest
+redis:
+  image: redis:7

--- a/src/xyte_mcp_alpha/celery_app.py
+++ b/src/xyte_mcp_alpha/celery_app.py
@@ -5,7 +5,8 @@ celery_app = Celery(
     "xyte_mcp",
     broker=os.getenv("REDIS_URL", "redis://localhost:6379/0"),
     backend=os.getenv(
-        "DATABASE_URL", "postgresql+asyncpg://mcp:pass@127.0.0.1/mcp"
+        "RESULT_BACKEND_URL",
+        os.getenv("DATABASE_URL", "postgresql+asyncpg://mcp:pass@127.0.0.1/mcp"),
     ),
 )
 celery_app.conf.update(

--- a/src/xyte_mcp_alpha/tasks.py
+++ b/src/xyte_mcp_alpha/tasks.py
@@ -36,8 +36,8 @@ async def send_command_async(
 ) -> ToolResponse:
     """Initiate a command asynchronously and return a task ID.
 
-    When ``ENABLE_ASYNC_TASKS`` is ``False`` return a deterministic
-    ``{"error": "async_disabled"}`` payload instead of executing.
+    When ``ENABLE_ASYNC_TASKS`` is ``False`` the command is executed
+    synchronously and the final result is returned directly.
     """
 
     if ctx is None:
@@ -46,7 +46,11 @@ async def send_command_async(
     from .config import get_settings
 
     if not get_settings().enable_async_tasks:
-        return ToolResponse(summary="async_disabled", data={"error": "async_disabled"})
+        # Execute synchronously when async tasks are disabled
+        from .tools.device import send_command, SendCommandArgs
+
+        result = await send_command(SendCommandArgs(**data.model_dump()), ctx)
+        return ToolResponse(summary="done", data={"status": "done", "result": result.data})
 
     req = ctx.request_context.request
     if req is None:


### PR DESCRIPTION
## Summary
- add ENABLE_ASYNC_TASKS fallback that runs commands synchronously
- support RESULT_BACKEND_URL in celery app
- document async processing in README and deployment guide
- provide docker-compose.celery.yaml example
- add simple Helm sub-chart for worker and redis

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_683f5f4b6f3c8325b70951d6315782d9