### PR TITLE
Implement Helm and deployment docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,5 @@ XYTE_API_KEY=
 # XYTE_RATE_LIMIT=60
 # Set to true to enable asynchronous tasks (Celery + DB/Redis required)
 ENABLE_ASYNC_TASKS=false
+# Comma separated list of plugin modules to load at startup
+XYTE_PLUGINS=

--- a/README.md
+++ b/README.md
@@ -10,15 +10,28 @@ An MCP (Model Context Protocol) server that provides access to the Xyte Organiza
 
 1. Ensure Python 3.11+ is installed and clone the repo.
 2. Create a virtualenv and install the project: `pip install -e .`.
-3. Copy `.env.example` to `.env` and then decide which mode to run:
+3. Copy `.env.example` to `.env`.
 
-|                     | Local (Single-tenant) | Hosted (Multi-tenant) |
-|---------------------|----------------------|-----------------------|
-| Env vars            | `XYTE_API_KEY=<key>` | *(leave blank)*       |
-| Optional async      | `ENABLE_ASYNC_TASKS=true` | `ENABLE_ASYNC_TASKS=true` |
-| Start server        | `python -m xyte_mcp_alpha.http` | `python -m xyte_mcp_alpha.http` |
-| Auth header         | none                 | `Authorization: <key>` |
-| Example curl        | `curl http://localhost:8080/v1/devices` | `curl -H "Authorization: $KEY" http://localhost:8080/v1/devices` |
+### Local / single-tenant
+
+1. Edit `.env` and set `XYTE_API_KEY=<key>`.
+2. Start the server:
+   ```bash
+   python -m xyte_mcp_alpha.http
+   ```
+3. Test it:
+   ```bash
+   curl http://localhost:8080/v1/devices
+   ```
+
+### Cloud / multi-tenant
+
+1. Leave `XYTE_API_KEY` empty in `.env`.
+2. Start the server (same command as above).
+3. Call the API with your key header:
+   ```bash
+   curl -H "Authorization: $KEY" http://localhost:8080/v1/devices
+   ```
 ## Setup
 
 ### Development

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -3,6 +3,16 @@
 This project provides a Helm chart and raw Kubernetes manifests for deploying the
 MCP server.
 
+## Mode Matrix
+
+Use the chart in one of three modes depending on your deployment needs.
+
+| Mode | Purpose | Sample `values.yaml` snippet |
+|------|---------|-----------------------------|
+| **Single-tenant** | API key baked into the deployment. | `multiTenant: false`<br>`env:`<br>&nbsp;&nbsp;`XYTE_API_KEY: "YOUR_KEY"` |
+| **Multi-tenant** | Hosted environment where each request provides its own key. | `multiTenant: true`<br>`env:`<br>&nbsp;&nbsp;`XYTE_API_KEY: ""` |
+| **Multi-tenant + Celery** | Hosted mode with asynchronous commands enabled. | `multiTenant: true`<br>`env:`<br>&nbsp;&nbsp;`XYTE_API_KEY: ""`<br>&nbsp;&nbsp;`ENABLE_ASYNC_TASKS: "true"`<br>`worker:`<br>&nbsp;&nbsp;`enabled: true` |
+
 ## Installing with Helm
 
 1. Ensure you have `helm` installed and access to a Kubernetes cluster.

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -1,6 +1,8 @@
 # Plugin System
 
-This document explains how to extend the MCP server with Python plugins.
+This document explains how to extend the MCP server with Python plugins. Set
+the `XYTE_PLUGINS` environment variable (or add it to your `.env` file) with a
+comma separated list of modules to load.
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- document plugin env var
- add mode matrix for Helm chart
- split quickstart into single-tenant and multi-tenant sections
- clarify example `.env` configuration

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_683f5f55a87c8325a8eac8adf8303ca2