### PR TITLE
Apply minor docs clean-ups

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,5 @@ XYTE_API_KEY=
 # XYTE_RATE_LIMIT=60
 # Set to true to enable asynchronous tasks (Celery + DB/Redis required)
 ENABLE_ASYNC_TASKS=false
+# Allow cross-origin requests from any domain (use with caution)
+XYTE_ALLOW_ALL_CORS=false

--- a/docs/wrappers.md
+++ b/docs/wrappers.md
@@ -30,5 +30,5 @@
 | `ticket://{ticket_id}` | get_ticket |
 | `user://{user_token}/preferences` | get_user_preferences |
 | `user://{user_token}/devices` | list_user_devices |
-| `device://{device_id}/logs` | device_logs |
+| `device://{device_id}/logs` | device_logs *(requires `XYTE_EXPERIMENTAL_APIS`)* |
 

--- a/src/xyte_mcp_alpha/user.py
+++ b/src/xyte_mcp_alpha/user.py
@@ -10,6 +10,7 @@ class UserPreferences(BaseModel):
     default_room: str | None = None
 
 # Example in-memory store mapping user tokens to preferences
+# This is for **demo purposes only** and is not persisted.
 USER_PREFERENCES: Dict[str, UserPreferences] = {
     "demo-token": UserPreferences(preferred_devices=["device1"], default_room="101"),
 }


### PR DESCRIPTION
## Summary
- clarify in-memory user preferences are demo-only
- mark device logs resource as experimental
- add CORS flag to `.env.example`

## Testing
- `pytest --maxfail=1 -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_683f5f74473883258678438850f9a138