### PR TITLE
Update deployment docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # Xyte MCP Server Configuration
-# Leave blank for hosted mode
+# Set this key to run in single-tenant mode.
+# Leave blank for hosted (multi-tenant) deployments
 XYTE_API_KEY=
 # Optional: Override the API base URL (defaults to production)
 # XYTE_BASE_URL=https://hub.xyte.io/core/v1/organization
@@ -9,7 +10,7 @@ XYTE_API_KEY=
 # XYTE_ENV=dev
 # Optional: max MCP requests per minute
 # XYTE_RATE_LIMIT=60
-# Comma-separated list of plugin modules to load
+# Comma-separated list of Python module paths to load as plugins
 # XYTE_PLUGINS=
 # OAuth token for multi-tenant deployments
 # XYTE_OAUTH_TOKEN=

--- a/README.md
+++ b/README.md
@@ -10,15 +10,34 @@ An MCP (Model Context Protocol) server that provides access to the Xyte Organiza
 
 1. Ensure Python 3.11+ is installed and clone the repo.
 2. Create a virtualenv and install the project: `pip install -e .`.
-3. Copy `.env.example` to `.env` and then decide which mode to run:
+3. Copy `.env.example` to `.env`.
 
-|                     | Local (Single-tenant) | Hosted (Multi-tenant) |
-|---------------------|----------------------|-----------------------|
-| Env vars            | `XYTE_API_KEY=<key>` | *(leave blank)*       |
-| Optional async      | `ENABLE_ASYNC_TASKS=true` | `ENABLE_ASYNC_TASKS=true` |
-| Start server        | `python -m xyte_mcp_alpha.http` | `python -m xyte_mcp_alpha.http` |
-| Auth header         | none                 | `Authorization: <key>` |
-| Example curl        | `curl http://localhost:8080/v1/devices` | `curl -H "Authorization: $KEY" http://localhost:8080/v1/devices` |
+### Local / single-tenant
+
+Set the API key in `.env` and start the server:
+
+```bash
+XYTE_API_KEY=your-key
+python -m xyte_mcp_alpha.http
+```
+
+Query devices:
+
+```bash
+curl http://localhost:8080/v1/devices
+```
+
+### Cloud / multi-tenant
+
+Leave `XYTE_API_KEY` blank and supply it per-request:
+
+```bash
+python -m xyte_mcp_alpha.http
+```
+
+```bash
+curl -H "Authorization: $KEY" http://localhost:8080/v1/devices
+```
 
 ### Async Tasks
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -13,6 +13,43 @@ MCP server.
    ```
 3. Override `image.repository` or `image.tag` if you push a custom image.
 
+## Deployment Modes
+
+The chart can run in three modes depending on your credentials and whether you
+use Celery for background tasks.
+
+| Mode | multiTenant | XYTE_API_KEY | ENABLE_ASYNC_TASKS | Notes |
+|------|-------------|--------------|--------------------|------|
+| Single-tenant | `false` | set | `false` | API key baked into the pod |
+| Multi-tenant | `true` | omit | `false` | Each request supplies the key |
+| Multi-tenant + Celery | `true` | omit | `true` | Requires worker and Redis |
+
+### Sample `values.yaml`
+
+Single-tenant:
+
+```yaml
+multiTenant: false
+env:
+  XYTE_API_KEY: "your-key"
+```
+
+Multi-tenant:
+
+```yaml
+multiTenant: true
+```
+
+Multi-tenant with Celery:
+
+```yaml
+multiTenant: true
+env:
+  ENABLE_ASYNC_TASKS: "true"
+worker:
+  enabled: true
+```
+
 ## Key Values
 
 - **image.repository** – Docker image to run.
@@ -78,17 +115,6 @@ executes the command synchronously and returns the result. Enabling the flag
 requires running Redis and a Celery worker (see sample `docker-compose.celery.yaml`)
 and tasks will persist across restarts.
 
-## Multi-tenant Helm Values
-
-To deploy in hosted (multi-tenant) mode, set `multiTenant=true` and omit the API key.
-Add `ENABLE_ASYNC_TASKS=true` and run a worker deployment if you need asynchronous commands:
-
-```yaml
-multiTenant: true
-env:
-  XYTE_API_KEY: ""
-  ENABLE_ASYNC_TASKS: "true"
-```
 
 ## Health Probes
 

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -1,6 +1,8 @@
 # Plugin System
 
 This document explains how to extend the MCP server with Python plugins.
+Plugins are enabled by listing their modules in the `XYTE_PLUGINS` environment
+variable or via Python entry points.
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- expand deployment guide with mode matrix and sample values
- update quickstart with separate local and cloud instructions
- clarify plugin loading and `.env` options

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_683fee1e865c832596d2231149ae79f8