### PR TITLE
Implement minor cleanup tasks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,8 @@ XYTE_API_KEY=
 # XYTE_OAUTH_TOKEN=
 # User token for multi-tenant deployments
 # XYTE_USER_TOKEN=
+# Allow all origins for CORS (set to true only for dev)
+XYTE_ALLOW_ALL_CORS=false
 # Set to true to enable asynchronous tasks (Celery + DB/Redis required)
 ENABLE_ASYNC_TASKS=false
 # Redis broker URL

--- a/src/xyte_mcp_alpha/server.py
+++ b/src/xyte_mcp_alpha/server.py
@@ -178,8 +178,6 @@ async def _device_status_wrapper(device_id: str) -> Dict[str, Any]:
     return await resources.device_status(_req(), device_id)
 
 
-async def _device_logs_wrapper(device_id: str) -> Dict[str, Any]:
-    return await resources.device_logs(_req(), device_id)
 
 
 async def _organization_info_wrapper(device_id: str) -> Dict[str, Any]:
@@ -223,6 +221,9 @@ mcp.resource(
     description="Current status of a device",
 )(instrument("resource", "device_status")(_device_status_wrapper))
 if get_settings().enable_experimental_apis:
+    async def _device_logs_wrapper(device_id: str) -> Dict[str, Any]:
+        return await resources.device_logs(_req(), device_id)
+
     mcp.resource(
         "device://{device_id}/logs",
         description="Recent logs for a device",

--- a/src/xyte_mcp_alpha/user.py
+++ b/src/xyte_mcp_alpha/user.py
@@ -10,6 +10,7 @@ class UserPreferences(BaseModel):
     default_room: str | None = None
 
 # Example in-memory store mapping user tokens to preferences
+# Demo only, not persisted across restarts
 USER_PREFERENCES: Dict[str, UserPreferences] = {
     "demo-token": UserPreferences(preferred_devices=["device1"], default_room="101"),
 }


### PR DESCRIPTION
## Summary
- update in-memory preference comment
- guard device_logs resource behind config
- document CORS variable in `.env.example`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683feea3d75c832596502dff726b98be